### PR TITLE
Ticket/aotech 6651 maintain post ids

### DIFF
--- a/assets/js/press-sync.js
+++ b/assets/js/press-sync.js
@@ -78,7 +78,6 @@ window.PressSync = ( function( window, document, $ ) {
 	app.syncData = function( paged, objects_to_sync ) {
 
 		$.ajax({
-			async: false,
 			method: "POST",
 			url: press_sync.ajax_url,
 			data: {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -282,7 +282,7 @@ class API extends \WP_REST_Controller {
 		$post_args['ID'] = isset( $local_post['ID'] ) ? $local_post['ID'] : 0;
 
 		// Keep the ID because we found a regular ol' duplicate.
-		if ( $this->preserve_ids && ! $local_post ) {
+		if ( $this->preserve_ids && ! $local_post && ! empty( $post_args['ID'] ) ) {
 			$post_args['import_id'] = $post_args['ID'];
 			unset( $post_args['ID'] );
 		}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -279,13 +279,10 @@ class API extends \WP_REST_Controller {
 			$local_post = $this->get_non_synced_duplicate( $post_args );
 		}
 
-        // @TODO this logic needs cleanup.
-        if ( ! $this->preserve_ids ) {
-            // Update the existing ID of the post if present.
-            $post_args['ID'] = isset( $local_post['ID'] ) ? $local_post['ID'] : 0;
-        }
+        $post_args['ID'] = isset( $local_post['ID'] ) ? $local_post['ID'] : 0;
 
-        if ( $this->preserve_ids && ! $local_post && isset( $post_args['ID'] ) ) {
+        // Keep the ID because we found a regular ol' duplicate.
+        if ( $this->preserve_ids && ! $local_post ) {
             $post_args['import_id'] = $post_args['ID'];
             unset( $post_args['ID'] );
         }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -394,7 +394,12 @@ class API extends \WP_REST_Controller {
 					$attachment_id = $duplicate['ID'];
 				} else {
 					$attachment_args['post_author'] = $this->get_press_sync_author_id( $attachment_args['post_author'] );
-					$attachment_id                  = wp_insert_post( $attachment_args );
+					if ( isset( $attachment_args['ID'] ) ) {
+						$attachment_args['import_id'] = $attachment_args['ID'];
+						unset( $attachment_args['ID'] );
+					}
+
+					$attachment_id = wp_insert_post( $attachment_args );
 				}
 
 				$this->update_post_meta_array( $attachment_id, $attachment_args['meta_input' ] );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -981,16 +981,16 @@ SQL;
 
                 // Handle $values as an array.
                 if ( 1 === count( $values ) ) {
-                    update_post_meta( $post_id, $field, current( $values ) );
+                    update_post_meta( $post_id, $field, maybe_unserialize( current( $values ) ) );
                 } else {
                     // Also handle multiple keys by removing and re-adding.
                     delete_post_meta( $post_id, $field );
                     foreach ( $values as $value ) {
-                        add_post_meta( $post_id, $field, $value );
+                        add_post_meta( $post_id, $field, maybe_unserialize( $value ) );
                     }
                 }
             } else {
-                update_post_meta( $post_id, $field, $values );
+                update_post_meta( $post_id, $field, maybe_unserialize( $values ) );
             }
         }
     }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -261,7 +261,7 @@ class API extends \WP_REST_Controller {
 		$post_args['post_author'] = $this->get_press_sync_author_id( $post_args['post_author'] );
 
 		// Check for post parent and update IDs accordingly.
-		if ( isset( $post_args['post_parent'] ) && $post_parent_id = $post_args['post_parent'] ) {
+		if ( ! $this->preserve_ids && isset( $post_args['post_parent'] ) && $post_parent_id = $post_args['post_parent'] ) {
 
 			$post_parent_args['post_type'] = $post_args['post_type'];
 			$post_parent_args['meta_input']['press_sync_post_id'] = $post_parent_id;

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -279,14 +279,15 @@ class API extends \WP_REST_Controller {
 			$local_post = $this->get_non_synced_duplicate( $post_args );
 		}
 
+        // @TODO this logic needs cleanup.
         if ( ! $this->preserve_ids ) {
             // Update the existing ID of the post if present.
             $post_args['ID'] = isset( $local_post['ID'] ) ? $local_post['ID'] : 0;
-        } else {
-            if ( isset( $post_args['ID'] ) ) {
-                $post_args['import_id'] = $post_args['ID'];
-                unset( $post_args['ID'] );
-            }
+        }
+
+        if ( $this->preserve_ids && ! $local_post && isset( $post_args['ID'] ) ) {
+            $post_args['import_id'] = $post_args['ID'];
+            unset( $post_args['ID'] );
         }
 
 		// Determine which content is newer, local or remote.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -395,7 +395,8 @@ class API extends \WP_REST_Controller {
                 if ( $duplicate = $this->get_non_synced_duplicate( $attachment_args ) ) {
                     $attachment_id = $duplicate['ID'];
                 } else {
-                    $attachment_id = wp_insert_post( $attachment_args );
+                    $attachment_args['post_author'] = $this->get_press_sync_author_id( $attachment_args['post_author'] );
+                    $attachment_id                  = wp_insert_post( $attachment_args );
                 }
 
                 $this->update_post_meta_array( $attachment_id, $attachment_args['meta_input' ] );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -389,10 +389,11 @@ class API extends \WP_REST_Controller {
                 // Look for a duplicate.
                 if ( $duplicate = $this->get_non_synced_duplicate( $attachment_args ) ) {
                     $attachment_id = $duplicate['ID'];
-                    $this->update_post_meta_array( $attachment_id, $attachment_args['meta_input' ] );
                 } else {
                     $attachment_id = wp_insert_post( $attachment_args );
                 }
+
+                $this->update_post_meta_array( $attachment_id, $attachment_args['meta_input' ] );
             }
         }
         catch( \Exception $e ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -68,12 +68,12 @@ class API extends \WP_REST_Controller {
 			'permission_callback' => array( $this, 'validate_sync_key' ),
 		) );
 
-        register_rest_route( 'press-sync/v1', '/progress/', array(
-            'methods'             => array( 'GET' ),
-            'callback'            => array( $this, 'get_sync_progress' ),
-            'permission_callback' => array( $this, 'validate_sync_key' ),
-            'args'                => array( 'post_type', 'press_sync_key' ),
-        ) );
+		register_rest_route( 'press-sync/v1', '/progress/', array(
+			'methods'             => array( 'GET' ),
+			'callback'            => array( $this, 'get_sync_progress' ),
+			'permission_callback' => array( $this, 'validate_sync_key' ),
+			'args'                => array( 'post_type', 'press_sync_key' ),
+		) );
 
 		/*
 		@todo Complete the individual post syncing.
@@ -81,7 +81,7 @@ class API extends \WP_REST_Controller {
 			'methods' => array( 'GET', 'POST' ),
 			'callback' => array( $this, 'sync_objects' ),
 		) );
-		*/
+		 */
 
 	}
 
@@ -173,7 +173,7 @@ class API extends \WP_REST_Controller {
 		$duplicate_action   = $request->get_param( 'duplicate_action' ) ? $request->get_param( 'duplicate_action' ) : 'skip';
 		$force_update       = $request->get_param( 'force_update' );
 		$this->skip_assets  = (bool) $request->get_param( 'skip_assets' );
-        $this->preserve_ids = (bool) $request->get_param( 'preserve_ids' );
+		$this->preserve_ids = (bool) $request->get_param( 'preserve_ids' );
 
 		if ( ! $objects_to_sync ) {
 			wp_send_json_error( array(
@@ -230,7 +230,7 @@ class API extends \WP_REST_Controller {
 	 * @param array   $post_args        The WP Posts to sync.
 	 * @param string  $duplicate_action A flag to direct whether or not content is duplicated.
 	 * @param boolean $force_update     A flag to overwrite existing content.
-     * @TODO add filter for incoming post data before save.
+	 * @TODO add filter for incoming post data before save.
 	 *
 	 * @return array
 	 */
@@ -279,13 +279,13 @@ class API extends \WP_REST_Controller {
 			$local_post = $this->get_non_synced_duplicate( $post_args );
 		}
 
-        $post_args['ID'] = isset( $local_post['ID'] ) ? $local_post['ID'] : 0;
+		$post_args['ID'] = isset( $local_post['ID'] ) ? $local_post['ID'] : 0;
 
-        // Keep the ID because we found a regular ol' duplicate.
-        if ( $this->preserve_ids && ! $local_post ) {
-            $post_args['import_id'] = $post_args['ID'];
-            unset( $post_args['ID'] );
-        }
+		// Keep the ID because we found a regular ol' duplicate.
+		if ( $this->preserve_ids && ! $local_post ) {
+			$post_args['import_id'] = $post_args['ID'];
+			unset( $post_args['ID'] );
+		}
 
 		// Determine which content is newer, local or remote.
 		if ( ! $force_update && $local_post && ( strtotime( $local_post['post_modified'] ) >= strtotime( $post_args['post_modified'] ) ) ) {
@@ -346,7 +346,7 @@ class API extends \WP_REST_Controller {
 				'remote_post_id'  => $post_args['meta_input']['press_sync_post_id'],
 				'local_post_id'   => $local_post_id,
 				'message'         => __( 'The post has been synced with the remote site', 'press-sync' ),
-                'featured_result' => $featured_result,
+				'featured_result' => $featured_result,
 			),
 		);
 	}
@@ -369,41 +369,41 @@ class API extends \WP_REST_Controller {
 			return false;
 		}
 
-        try {
-            if ( ! $this->skip_assets ) {
-                $attachment = $this->maybe_upload_remote_attachment( $attachment_args );
+		try {
+			if ( ! $this->skip_assets ) {
+				$attachment = $this->maybe_upload_remote_attachment( $attachment_args );
 
-                // ID will only be set if we find the attachment is already here.
-                if ( ! isset( $attachment['ID'] ) ) {
-                    $filename = $attachment['filename'];
-                    unset( $attachment['filename'] );
+				// ID will only be set if we find the attachment is already here.
+				if ( ! isset( $attachment['ID'] ) ) {
+					$filename = $attachment['filename'];
+					unset( $attachment['filename'] );
 
-                    $attachment_id = wp_insert_attachment( $attachment, $filename, 0 );
+					$attachment_id = wp_insert_attachment( $attachment, $filename, 0 );
 
-                    if ( is_wp_error( $attachment_id ) ) {
-                        throw new \Exception( 'There was an error creating the attachment: ' . $attachment_id->get_error_message() );
-                    }
+					if ( is_wp_error( $attachment_id ) ) {
+						throw new \Exception( 'There was an error creating the attachment: ' . $attachment_id->get_error_message() );
+					}
 
-                    // Generate the metadata for the attachment, and update the database record.
-                    $attachment_data = wp_generate_attachment_metadata( $attachment_id, $filename );
-                    wp_update_attachment_metadata( $attachment_id, $attachment_data );
-                }
-            } else {
-                // Look for a duplicate.
-                if ( $duplicate = $this->get_non_synced_duplicate( $attachment_args ) ) {
-                    $attachment_id = $duplicate['ID'];
-                } else {
-                    $attachment_args['post_author'] = $this->get_press_sync_author_id( $attachment_args['post_author'] );
-                    $attachment_id                  = wp_insert_post( $attachment_args );
-                }
+					// Generate the metadata for the attachment, and update the database record.
+					$attachment_data = wp_generate_attachment_metadata( $attachment_id, $filename );
+					wp_update_attachment_metadata( $attachment_id, $attachment_data );
+				}
+			} else {
+				// Look for a duplicate.
+				if ( $duplicate = $this->get_non_synced_duplicate( $attachment_args ) ) {
+					$attachment_id = $duplicate['ID'];
+				} else {
+					$attachment_args['post_author'] = $this->get_press_sync_author_id( $attachment_args['post_author'] );
+					$attachment_id                  = wp_insert_post( $attachment_args );
+				}
 
-                $this->update_post_meta_array( $attachment_id, $attachment_args['meta_input' ] );
-            }
-        }
-        catch( \Exception $e ) {
-            // @TODO log it more!
-            error_log( $e->getMessage() );
-        }
+				$this->update_post_meta_array( $attachment_id, $attachment_args['meta_input' ] );
+			}
+		}
+		catch( \Exception $e ) {
+			// @TODO log it more!
+			error_log( $e->getMessage() );
+		}
 
 		return $attachment_id;
 	}
@@ -485,9 +485,9 @@ class API extends \WP_REST_Controller {
 	 * @since 0.1.0
 	 *
 	 * @param array $post_args The WP Post args to query.
-     * @since 0.4.5
-     * @param bool $respect_post_type Set false to look for a post regardless of post type.
-     *
+	 * @since 0.4.5
+	 * @param bool $respect_post_type Set false to look for a post regardless of post type.
+	 *
 	 * @return WP_Post
 	 */
 	public function get_synced_post( $post_args, $respect_post_type = true ) {
@@ -500,16 +500,16 @@ class API extends \WP_REST_Controller {
 		$sql = "
 			SELECT post_id AS ID, post_title, post_type, post_modified FROM $wpdb->postmeta AS meta
 			LEFT JOIN $wpdb->posts AS posts ON posts.ID = meta.post_id
-            WHERE meta.meta_key = 'press_sync_post_id' AND meta.meta_value = %d";
+			WHERE meta.meta_key = 'press_sync_post_id' AND meta.meta_value = %d";
 
-        $prepare_args = array( $press_sync_post_id );
+		$prepare_args = array( $press_sync_post_id );
 
-        if  ( $respect_post_type ) {
-            $sql           .= ' AND posts.post_type = %s ';
-            $prepare_args[] = $post_args['post_type'];
-        }
+		if  ( $respect_post_type ) {
+			$sql           .= ' AND posts.post_type = %s ';
+			$prepare_args[] = $post_args['post_type'];
+		}
 
-        $sql .= ' LIMIT 1';
+		$sql .= ' LIMIT 1';
 
 		$prepared_sql = $wpdb->prepare( $sql, $prepare_args );
 		$post         = $wpdb->get_row( $prepared_sql, ARRAY_A );
@@ -599,9 +599,9 @@ class API extends \WP_REST_Controller {
 		global $wpdb;
 
 		$sql = "SELECT ID, post_modified
-		FROM $wpdb->posts AS posts
-		LEFT JOIN $wpdb->postmeta AS meta ON meta.post_id = posts.ID
-		WHERE meta.meta_key = 'press_sync_post_id' AND meta.meta_value = $press_sync_post_id";
+			FROM $wpdb->posts AS posts
+			LEFT JOIN $wpdb->postmeta AS meta ON meta.post_id = posts.ID
+			WHERE meta.meta_key = 'press_sync_post_id' AND meta.meta_value = $press_sync_post_id";
 
 		return $wpdb->get_row( $sql );
 	}
@@ -658,7 +658,7 @@ class API extends \WP_REST_Controller {
 		// Remove filter that allowed an external request to be made via download_url().
 		remove_filter( 'http_request_host_is_external', array( $this, 'allow_sync_external_host' ) );
 
-        return $response ? '' : "Error attaching thumbnail {$thumbnail_id} to post {$post_id}";
+		return $response ? '' : "Error attaching thumbnail {$thumbnail_id} to post {$post_id}";
 	}
 
 	/**
@@ -793,40 +793,40 @@ class API extends \WP_REST_Controller {
 	 *
 	 * @since 0.1.0
 	 *
-     * @since 0.6.0
+	 * @since 0.6.0
 	 * @param string $post_args The post arguments for the post being synced.
 	 *
 	 * @return WP_Post
 	 */
 	public function get_non_synced_duplicate( $post_args ) {
-        $duplicate_post = false;
+		$duplicate_post = false;
 
-        // @TODO post name and content checks should be their own methods...later, in the Post sync class.
+		// @TODO post name and content checks should be their own methods...later, in the Post sync class.
 
-        // Post name check.
+		// Post name check.
 		if ( ! empty( $post_args['post_name'] ) ) {
-            global $wpdb;
+			global $wpdb;
 
-            $sql          = "SELECT ID, post_title, post_type, post_modified FROM {$wpdb->posts} WHERE post_name = %s AND post_type = %s";
-            $prepared_sql = $wpdb->prepare( $sql, $post_args['post_name'], $post_args['post_type'] );
+			$sql          = "SELECT ID, post_title, post_type, post_modified FROM {$wpdb->posts} WHERE post_name = %s AND post_type = %s";
+			$prepared_sql = $wpdb->prepare( $sql, $post_args['post_name'], $post_args['post_type'] );
 
-            // get_row will return "null" or void on failure; in the words of Elvis "Well now goodbye `false` pretender".
-            $duplicate_post = $wpdb->get_row( $prepared_sql, ARRAY_A ) ?: false;
+			// get_row will return "null" or void on failure; in the words of Elvis "Well now goodbye `false` pretender".
+			$duplicate_post = $wpdb->get_row( $prepared_sql, ARRAY_A ) ?: false;
 		}
 
-        // Post content check.
-        $content_threshold = get_option( 'press_sync_content_threshold', false );
+		// Post content check.
+		$content_threshold = get_option( 'press_sync_content_threshold', false );
 
-        if ( $duplicate_post && false !== $content_threshold && 0 !== absint( $content_threshold ) ) {
-            $content_threshold = absint( $content_threshold );
+		if ( $duplicate_post && false !== $content_threshold && 0 !== absint( $content_threshold ) ) {
+			$content_threshold = absint( $content_threshold );
 
-            // Calculate how similar the post contents are (is?).
-            similar_text( $duplicate_post['post_content'], $post_args['post_content'], $similarity );
+			// Calculate how similar the post contents are (is?).
+			similar_text( $duplicate_post['post_content'], $post_args['post_content'], $similarity );
 
-            if ( $similarity < $content_threshold ) {
-                $duplicate_post = false;
-            }
-        }
+			if ( $similarity < $content_threshold ) {
+				$duplicate_post = false;
+			}
+		}
 
 		return $duplicate_post;
 	}
@@ -855,46 +855,46 @@ class API extends \WP_REST_Controller {
 
 	}
 
-    /**
-     * Returns the IDs of synced objects of the given post type.
-     *
-     * @since 0.6.0
-     *
-     * @param WP_REST_Request $request The REST request.
-     */
-    public function get_sync_progress( $request ) {
-        try {
-            $post_type = $request->get_param( 'post_type' );
-            $sql = <<<SQL
+	/**
+	 * Returns the IDs of synced objects of the given post type.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 */
+	public function get_sync_progress( $request ) {
+		try {
+			$post_type = $request->get_param( 'post_type' );
+			$sql = <<<SQL
 SELECT DISTINCT
-    pm.meta_value
+	pm.meta_value
 FROM
-    {$GLOBALS['wpdb']->postmeta} pm
+	{$GLOBALS['wpdb']->postmeta} pm
 WHERE
-    pm.meta_key = 'press_sync_post_id'
+	pm.meta_key = 'press_sync_post_id'
 AND
-    pm.post_id IN(
-        SELECT ID FROM
-            {$GLOBALS['wpdb']->posts} p
-        WHERE
-            p.post_status NOT IN( 'auto-draft', 'trash' )
-        AND
-            p.post_type = 'post'
-    )
+	pm.post_id IN(
+		SELECT ID FROM
+			{$GLOBALS['wpdb']->posts} p
+		WHERE
+			p.post_status NOT IN( 'auto-draft', 'trash' )
+		AND
+			p.post_type = 'post'
+	)
 SQL;
 
-            $query  = $GLOBALS['wpdb']->prepare( $sql, $post_type );
-            $synced = $GLOBALS['wpdb']->get_col( $query );
+			$query  = $GLOBALS['wpdb']->prepare( $sql, $post_type );
+			$synced = $GLOBALS['wpdb']->get_col( $query );
 
-            wp_send_json_success( array(
-                'synced' => $synced,
-            ) );
-        } catch ( \Exception $e ) {
-            wp_send_json_error();
-        }
-    }
+			wp_send_json_success( array(
+				'synced' => $synced,
+			) );
+		} catch ( \Exception $e ) {
+			wp_send_json_error();
+		}
+	}
 
-    private function maybe_upload_remote_attachment( $attachment_args ) {
+	private function maybe_upload_remote_attachment( $attachment_args ) {
 		$attachment_url       = isset( $attachment_args['details']['url'] ) ? $attachment_args['details']['url'] : $attachment_args['attachment_url'];
 		$attachment_post_date = isset( $attachment_args['details']['post_date'] ) ? $attachment_args['details']['post_date'] : $attachment_args['post_date'];
 		$attachment_title     = isset( $attachment_args['post_title'] ) ? $attachment_args['post_title'] : '';
@@ -905,92 +905,92 @@ SQL;
 			return array( 'ID' => $attachment_id );
 		}
 
-        $attachment_metadata = $this->get_attachment_metadata_from_request( $attachment_args );
-        $temp_file           = false;
+		$attachment_metadata = $this->get_attachment_metadata_from_request( $attachment_args );
+		$temp_file           = false;
 
-        require_once( ABSPATH . '/wp-admin/includes/image.php' );
-        require_once( ABSPATH . '/wp-admin/includes/file.php' );
-        require_once( ABSPATH . '/wp-admin/includes/media.php' );
+		require_once( ABSPATH . '/wp-admin/includes/image.php' );
+		require_once( ABSPATH . '/wp-admin/includes/file.php' );
+		require_once( ABSPATH . '/wp-admin/includes/media.php' );
 
-        // Download the url.
-        $temp_file = download_url( $attachment_url, 5000 );
+		// Download the url.
+		$temp_file = download_url( $attachment_url, 5000 );
 
-        // Move the file to the proper uploads folder.
-        if ( is_wp_error( $temp_file ) ) {
-            // @TODO log it!
-            throw new \Exception( 'Something went wrong when downloading the attachment temp file: ' . $temp_file->get_error_message() );
-        }
+		// Move the file to the proper uploads folder.
+		if ( is_wp_error( $temp_file ) ) {
+			// @TODO log it!
+			throw new \Exception( 'Something went wrong when downloading the attachment temp file: ' . $temp_file->get_error_message() );
+		}
 
-        // Array based on $_FILE as seen in PHP file uploads.
-        $file = array(
-            'name'     => basename( $attachment_url ),
-            'type'     => 'image/png',
-            'tmp_name' => $temp_file,
-            'error'    => 0,
-            'size'     => filesize( $temp_file ),
-        );
+		// Array based on $_FILE as seen in PHP file uploads.
+		$file = array(
+			'name'     => basename( $attachment_url ),
+			'type'     => 'image/png',
+			'tmp_name' => $temp_file,
+			'error'    => 0,
+			'size'     => filesize( $temp_file ),
+		);
 
-        $overrides = array( 'test_form' => false, 'test_size' => true, 'action' => 'custom' );
+		$overrides = array( 'test_form' => false, 'test_size' => true, 'action' => 'custom' );
 
-        if ( false !== $temp_file ) {
-            // Move the temporary file into the uploads directory.
-            $results = wp_handle_upload( $file, $overrides, $attachment_post_date );
+		if ( false !== $temp_file ) {
+			// Move the temporary file into the uploads directory.
+			$results = wp_handle_upload( $file, $overrides, $attachment_post_date );
 
-            // Delete the temporary file.
-            @unlink( $temp_file );
-        }
+			// Delete the temporary file.
+			@unlink( $temp_file );
+		}
 
-        // Upload the file into WP Media Library.
-        if ( $results['file'] ) {
-            $filename  = $results['file']; // Full path to the file.
-            $local_url = $results['url'];  // URL to the file in the uploads dir.
-            $type      = $results['type']; // MIME type of the file.
-        }
+		// Upload the file into WP Media Library.
+		if ( $results['file'] ) {
+			$filename  = $results['file']; // Full path to the file.
+			$local_url = $results['url'];  // URL to the file in the uploads dir.
+			$type      = $results['type']; // MIME type of the file.
+		}
 
-        // Prepare an array of post data for the attachment.
-        $attachment = array(
-            'guid'           => $local_url,
-            'post_mime_type' => $type,
-            'post_title'     => $attachment_title ?: preg_replace( '/\.[^.]+$/', '', basename( $filename ) ),
-            'post_content'   => '',
-            'post_status'    => 'inherit',
-            'filename'       => $filename,
-        );
+		// Prepare an array of post data for the attachment.
+		$attachment = array(
+			'guid'           => $local_url,
+			'post_mime_type' => $type,
+			'post_title'     => $attachment_title ?: preg_replace( '/\.[^.]+$/', '', basename( $filename ) ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+			'filename'       => $filename,
+		);
 
-        if ( strlen( $attachment_name ) ) {
-            $attachment['post_name'] = $attachment_name;
-        }
+		if ( strlen( $attachment_name ) ) {
+			$attachment['post_name'] = $attachment_name;
+		}
 
-        return $attachment;
-    }
+		return $attachment;
+	}
 
-    /**
-     * Bulk updates meta data from an array.
-     *
-     * @since 0.6.0
-     *
-     * @param int   $post_id   The ID of the post you want to update meta on.
-     * @param array $meta_data An array with keys and values also contained in an array ala get_post_meta( $ID ).
-     */
-    private function update_post_meta_array( $post_id, $meta_data = array() ) {
-        foreach ( $meta_data as $field => $values ) {
-            if ( is_array( $values ) ) {
-                update_post_meta( $post_id, $field, current( $values ) );
-                continue;
+	/**
+	 * Bulk updates meta data from an array.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param int   $post_id   The ID of the post you want to update meta on.
+	 * @param array $meta_data An array with keys and values also contained in an array ala get_post_meta( $ID ).
+	 */
+	private function update_post_meta_array( $post_id, $meta_data = array() ) {
+		foreach ( $meta_data as $field => $values ) {
+			if ( is_array( $values ) ) {
+				update_post_meta( $post_id, $field, current( $values ) );
+				continue;
 
-                // Handle $values as an array.
-                if ( 1 === count( $values ) ) {
-                    update_post_meta( $post_id, $field, maybe_unserialize( current( $values ) ) );
-                } else {
-                    // Also handle multiple keys by removing and re-adding.
-                    delete_post_meta( $post_id, $field );
-                    foreach ( $values as $value ) {
-                        add_post_meta( $post_id, $field, maybe_unserialize( $value ) );
-                    }
-                }
-            } else {
-                update_post_meta( $post_id, $field, maybe_unserialize( $values ) );
-            }
-        }
-    }
+				// Handle $values as an array.
+				if ( 1 === count( $values ) ) {
+					update_post_meta( $post_id, $field, maybe_unserialize( current( $values ) ) );
+				} else {
+					// Also handle multiple keys by removing and re-adding.
+					delete_post_meta( $post_id, $field );
+					foreach ( $values as $value ) {
+						add_post_meta( $post_id, $field, maybe_unserialize( $value ) );
+					}
+				}
+			} else {
+				update_post_meta( $post_id, $field, maybe_unserialize( $values ) );
+			}
+		}
+	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -282,6 +282,11 @@ class API extends \WP_REST_Controller {
         if ( ! $this->preserve_ids ) {
             // Update the existing ID of the post if present.
             $post_args['ID'] = isset( $local_post['ID'] ) ? $local_post['ID'] : 0;
+        } else {
+            if ( isset( $post_args['ID'] ) ) {
+                $post_args['import_id'] = $post_args['ID'];
+                unset( $post_args['ID'] );
+            }
         }
 
 		// Determine which content is newer, local or remote.

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -132,11 +132,11 @@ class Dashboard {
 			return;
 		}
 
-		?>
+?>
 		<div class="update-nag notice is-dismissable">
 			<p><?php _e( '<strong>PressSync:</strong> You must define your PressSync key before you can recieve updates from another WordPress site. <a href="tools.php?page=press-sync&tab=settings">Set it now</a>', 'press-sync' ); ?></p>
 		</div>
-		<?php
+<?php
 	}
 
 	/**
@@ -144,7 +144,7 @@ class Dashboard {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return JSON 
+	 * @return JSON
 	 */
 	public function get_objects_to_sync_count_via_ajax() {
 

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -109,6 +109,7 @@ class Dashboard {
 		register_setting( 'press-sync-export', 'ps_only_sync_missing' );
         register_setting( 'press-sync-export', 'ps_testing_post' );
 		register_setting( 'press-sync-export', 'ps_skip_assets' );
+		register_setting( 'press-sync-export', 'ps_preserve_ids' );
 
         // Import page.
         register_setting( 'press-sync-import', 'ps_content_threshold' );

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -686,6 +686,9 @@ class Press_Sync {
 			'post_title'     => $object_args['post_title'],
 			'post_name'      => $object_args['post_name'],
 			'attachment_url' => $attachment_url,
+            'ID'             => $object_args['ID'],
+            'post_status'    => $object_args['post_status'],
+            'post_type'      => $object_args['post_type'],
 		);
 
 		return $args;
@@ -823,6 +826,7 @@ class Press_Sync {
 			'filename'  => $filename_parts[2],
 			'post_date' => $filename_parts[0] . '/' . $filename_parts[1],
 			'url'       => $attachment->guid,
+            'ID'        => $attachment->ID,
 		);
 
 		return $attachment_details;
@@ -993,6 +997,7 @@ class Press_Sync {
 			'skip_assets'      => get_option( 'ps_skip_assets', false ),
 			'options'          => get_option( 'ps_options_to_sync' ),
 			'local_folder'     => '',
+            'preserve_ids'     => get_option( 'ps_preserve_ids', false ),
 		) );
 	}
 

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -579,10 +579,12 @@ class Press_Sync {
 		$media = get_post( $thumbnail_id, ARRAY_A );
 		$media['meta_input'] = get_post_meta( $thumbnail_id );
 
-		// Filter out wp built-in meta.
-		foreach ( $media['meta_input'] as $meta_key => $meta_value ) {
-			if ( 0 === strpos( $meta_key, '_wp_' ) ) {
-				unset( $media['meta_input'][$meta_key] );
+		// Maybe filter out wp built-in meta.
+		if ( ! get_option( 'ps_skip_assets' ) ) {
+			foreach ( $media['meta_input'] as $meta_key => $meta_value ) {
+				if ( 0 === strpos( $meta_key, '_wp_' ) ) {
+					unset( $media['meta_input'][$meta_key] );
+				}
 			}
 		}
 

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -70,6 +70,7 @@ class Press_Sync {
 	 */
 	public function hooks() {
 		add_filter( 'http_request_host_is_external', array( $this, 'approve_localhost_urls' ), 10, 3 );
+        add_filter( 'press_sync_after_prepare_post_args_to_sync', array( $this, 'maybe_remove_post_id' ) );
 	}
 
 	/**
@@ -477,7 +478,15 @@ class Press_Sync {
 			$object_args['p2p_connections'] = $this->get_p2p_connections( $object_args['ID'] );
 		}
 
-		unset( $object_args['ID'] );
+        /**
+         * Runs after a post's arguments are prepared for syncing.
+         *
+         * @since NEXT
+         *
+         * @param  array $object_args The arguments after preparation.
+         * @return array
+         */
+        $object_args = apply_filters( 'press_sync_after_prepare_post_args_to_sync', $object_args );
 
 		return $object_args;
 
@@ -1152,5 +1161,22 @@ class Press_Sync {
         }
 
 		return  "{$url}wp-json/press-sync/v1/{$endpoint}?" . http_build_query( $query_args );
+    }
+
+    /**
+     * Removes post IDs if the option to preserve them isn't active.
+     *
+     * @since NEXT
+     *
+     * @param  array $object_args The object's prepared arguments.
+     * @return array
+     */
+    public function maybe_remove_post_id( $object_args ) {
+        if ( true === (bool) get_option( 'ps_preserve_ids' ) ) {
+            return $object_args;
+        }
+
+        unset( $object_args['ID'] );
+        return $object_args;
     }
 }

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -701,7 +701,7 @@ class Press_Sync {
             ),
 		);
 
-        $meta = get_post_meta( $object_args['import_id'] );
+        $meta = get_post_meta( $object_args['ID'] );
 
         foreach ( $meta as $key => $values ) {
             $args['meta_input'][ $key ] = $values[0];

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -1316,7 +1316,7 @@ class Press_Sync {
 
 		$page_offset = absint( get_option( 'ps_start_object_offset' ) );
 
-		if ( 0 < $page_offset && 1 === $next_page ) {
+		if ( 0 < $page_offset && 1 === absint( $next_page ) ) {
 
 			$page_offset = floor( $page_offset / 5 );
 			$next_page  += ( $page_offset - 1);

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -71,7 +71,7 @@ class Press_Sync {
 	public function hooks() {
 		add_filter( 'http_request_host_is_external', array( $this, 'approve_localhost_urls' ), 10, 3 );
 		add_filter( 'press_sync_order_to_sync_all', array( $this, 'order_to_sync_all' ), 10, 1 );
-        add_filter( 'press_sync_after_prepare_post_args_to_sync', array( $this, 'maybe_remove_post_id' ) );
+		add_filter( 'press_sync_after_prepare_post_args_to_sync', array( $this, 'maybe_remove_post_id' ) );
 	}
 
 	/**
@@ -211,17 +211,17 @@ class Press_Sync {
 
 		switch ( $objects_to_sync ) {
 
-			case 'user':
-				$objects = $this->get_users_to_sync( $next_page );
-				break;
+		case 'user':
+			$objects = $this->get_users_to_sync( $next_page );
+			break;
 
-			case 'option':
-				$objects = $this->get_options_to_sync( $next_page );
-				break;
+		case 'option':
+			$objects = $this->get_options_to_sync( $next_page );
+			break;
 
-			default:
-				$objects = $this->get_posts_to_sync( $objects_to_sync, $next_page, $taxonomies, $where_clause );
-				break;
+		default:
+			$objects = $this->get_posts_to_sync( $objects_to_sync, $next_page, $taxonomies, $where_clause );
+			break;
 		}
 
 		return $objects;
@@ -507,15 +507,15 @@ class Press_Sync {
 			$object_args['p2p_connections'] = $this->get_p2p_connections( $object_args['ID'] );
 		}
 
-        /**
-         * Runs after a post's arguments are prepared for syncing.
-         *
-         * @since NEXT
-         *
-         * @param  array $object_args The arguments after preparation.
-         * @return array
-         */
-        $object_args = apply_filters( 'press_sync_after_prepare_post_args_to_sync', $object_args );
+		/**
+		 * Runs after a post's arguments are prepared for syncing.
+		 *
+		 * @since NEXT
+		 *
+		 * @param  array $object_args The arguments after preparation.
+		 * @return array
+		 */
+		$object_args = apply_filters( 'press_sync_after_prepare_post_args_to_sync', $object_args );
 
 		return $object_args;
 
@@ -695,28 +695,28 @@ class Press_Sync {
 			'post_title'     => $object_args['post_title'],
 			'post_name'      => $object_args['post_name'],
 			'attachment_url' => $attachment_url,
-            'post_type'      => $object_args['post_type'],
-            'meta_input' => array(
-                'press_sync_post_id' => $object_args['ID'],
-            ),
-            'post_author' => $object_args['post_author'],
-            'post_parent' => $object_args['post_parent'],
+			'post_type'      => $object_args['post_type'],
+			'meta_input' => array(
+				'press_sync_post_id' => $object_args['ID'],
+			),
+			'post_author' => $object_args['post_author'],
+			'post_parent' => $object_args['post_parent'],
 		);
 
-        $meta = get_post_meta( $object_args['ID'] );
+		$meta = get_post_meta( $object_args['ID'] );
 
-        foreach ( $meta as $key => $values ) {
-            $args['meta_input'][ $key ] = $values[0];
-        }
+		foreach ( $meta as $key => $values ) {
+			$args['meta_input'][ $key ] = $values[0];
+		}
 
-        if ( get_option( 'ps_skip_assets' ) ) {
-            $args['guid']           = $object_args['guid'];
-            $args['post_mime_type'] = $object_args['post_mime_type'];
-        }
+		if ( get_option( 'ps_skip_assets' ) ) {
+			$args['guid']           = $object_args['guid'];
+			$args['post_mime_type'] = $object_args['post_mime_type'];
+		}
 
-        if ( get_option( 'ps_preserve_ids' ) ) {
-            $args['import_id'] = $object_args['ID'];
-        }
+		if ( get_option( 'ps_preserve_ids' ) ) {
+			$args['import_id'] = $object_args['ID'];
+		}
 
 		return $args;
 	}
@@ -853,7 +853,7 @@ class Press_Sync {
 			'filename'  => $filename_parts[2],
 			'post_date' => $filename_parts[0] . '/' . $filename_parts[1],
 			'url'       => $attachment->guid,
-            'ID'        => $attachment->ID,
+			'ID'        => $attachment->ID,
 		);
 
 		return $attachment_details;
@@ -1024,7 +1024,7 @@ class Press_Sync {
 			'skip_assets'      => get_option( 'ps_skip_assets', false ),
 			'options'          => get_option( 'ps_options_to_sync' ),
 			'local_folder'     => '',
-            'preserve_ids'     => get_option( 'ps_preserve_ids', false ),
+			'preserve_ids'     => get_option( 'ps_preserve_ids', false ),
 		) );
 	}
 
@@ -1327,22 +1327,22 @@ class Press_Sync {
 		return $next_page;
 	}
 
-    /**
-     * Removes post IDs if the option to preserve them isn't active.
-     *
-     * @since NEXT
-     *
-     * @param  array $object_args The object's prepared arguments.
-     * @return array
-     */
-    public function maybe_remove_post_id( $object_args ) {
-        $object_args['import_id'] = $object_args['ID'];
-        unset( $object_args['ID'] );
+	/**
+	 * Removes post IDs if the option to preserve them isn't active.
+	 *
+	 * @since NEXT
+	 *
+	 * @param  array $object_args The object's prepared arguments.
+	 * @return array
+	 */
+	public function maybe_remove_post_id( $object_args ) {
+		$object_args['import_id'] = $object_args['ID'];
+		unset( $object_args['ID'] );
 
-        if ( true !== (bool) get_option( 'ps_preserve_ids' ) ) {
-            unset( $object_args['import_id'] );
-        }
+		if ( true !== (bool) get_option( 'ps_preserve_ids' ) ) {
+			unset( $object_args['import_id'] );
+		}
 
-        return $object_args;
-    }
+		return $object_args;
+	}
 }

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -695,10 +695,25 @@ class Press_Sync {
 			'post_title'     => $object_args['post_title'],
 			'post_name'      => $object_args['post_name'],
 			'attachment_url' => $attachment_url,
-            'ID'             => $object_args['ID'],
-            'post_status'    => $object_args['post_status'],
             'post_type'      => $object_args['post_type'],
+            'meta_input' => array(
+                'press_sync_post_id' => $object_args['ID'],
+            ),
 		);
+
+        $meta = get_post_meta( $object_args['import_id'] );
+
+        foreach ( $meta as $key => $values ) {
+            $args['meta_input'][ $key ] = $values[0];
+        }
+
+        if ( get_option( 'ps_skip_assets' ) ) {
+            $args['guid'] = $object_args['guid'];
+        }
+
+        if ( get_option( 'ps_preserve_ids' ) ) {
+            $args['import_id'] = $object_args['ID'];
+        }
 
 		return $args;
 	}
@@ -1318,11 +1333,13 @@ class Press_Sync {
      * @return array
      */
     public function maybe_remove_post_id( $object_args ) {
-        if ( true === (bool) get_option( 'ps_preserve_ids' ) ) {
-            return $object_args;
+        $object_args['import_id'] = $object_args['ID'];
+        unset( $object_args['ID'] );
+
+        if ( true !== (bool) get_option( 'ps_preserve_ids' ) ) {
+            unset( $object_args['import_id'] );
         }
 
-        unset( $object_args['ID'] );
         return $object_args;
     }
 }

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -699,6 +699,8 @@ class Press_Sync {
             'meta_input' => array(
                 'press_sync_post_id' => $object_args['ID'],
             ),
+            'post_author' => $object_args['post_author'],
+            'post_parent' => $object_args['post_parent'],
 		);
 
         $meta = get_post_meta( $object_args['ID'] );
@@ -708,7 +710,8 @@ class Press_Sync {
         }
 
         if ( get_option( 'ps_skip_assets' ) ) {
-            $args['guid'] = $object_args['guid'];
+            $args['guid']           = $object_args['guid'];
+            $args['post_mime_type'] = $object_args['post_mime_type'];
         }
 
         if ( get_option( 'ps_preserve_ids' ) ) {

--- a/views/dashboard/html-export.php
+++ b/views/dashboard/html-export.php
@@ -23,6 +23,14 @@ if ( ! apply_filters( 'press_sync_show_advanced_options', false ) ) {
                     <p>Attachments will still be synced, however their file assets will <strong>NOT</strong> be copied to the remote site.</p>
                 </td>
             </tr>
+            <tr valign="top">
+                <th scope="row">Preserve Post-type Object IDs</th>
+                <td>
+                <input type="checkbox" name="ps_preserve_ids" <?php checked( get_option( 'ps_preserve_ids' ) ); ?> value="1" />
+                    <span>Enable this option to maintain post IDs. <strong>N.B.:</strong> this can cause issues if you're syncing
+                    to a site that has content that was not synced with Press Sync due to ID collisions, use with care.</span>
+                </td>
+            </tr>
 			<tr valign="top">
 				<td colspan="2">
                     <p><strong>Settings below this line may affect performance if altered.</strong></p>


### PR DESCRIPTION
This PR adds the ability to preserve post IDs when syncing via the "Advanced Export" tab using the option **Preserve Post-type Object IDs**. This will use the `import_id` parameter to *nudge* WordPress to create a new post with a predefined ID.