### PR TITLE
Feature/store synced posts

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -363,10 +363,16 @@ class API extends \WP_REST_Controller {
 	 * @return int
 	 */
 	public function sync_attachment( $attachment_args, $duplicate_action = 'skip', $force_update = false ) {
+		$attachment_id = false;
+		$import_id     = false;
 
 		// Attachment URL does not exist so bail early.
 		if ( ! $this->skip_assets && ! array_key_exists( 'attachment_url', $attachment_args ) ) {
 			return false;
+		}
+
+		if ( isset( $attachment_args['ID'] ) ) {
+			$import_id = $attachment_args['ID'];
 		}
 
 		try {
@@ -403,6 +409,10 @@ class API extends \WP_REST_Controller {
 				}
 
 				$this->update_post_meta_array( $attachment_id, $attachment_args['meta_input' ] );
+			}
+
+			if ( $attachment_id && $import_id ) {
+				update_post_meta( $attachment_id, 'press_sync_post_id', $import_id );
 			}
 		}
 		catch( \Exception $e ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -858,6 +858,11 @@ class API extends \WP_REST_Controller {
     public function get_sync_progress( $request ) {
         try {
             $post_type = $request->get_param( 'post_type' );
+
+            if ( ! post_type_exists( $post_type ) ) {
+                $post_type = 'post';
+            }
+
             $sql = <<<SQL
 SELECT DISTINCT
     pm.meta_value
@@ -872,7 +877,7 @@ AND
         WHERE
             p.post_status NOT IN( 'auto-draft', 'trash' )
         AND
-            p.post_type = 'post'
+            p.post_type = %s
     )
 SQL;
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -828,7 +828,7 @@ class API extends \WP_REST_Controller {
 			// Calculate how similar the post contents are (is?).
 			similar_text( $duplicate_post['post_content'], $post_args['post_content'], $similarity );
 
-			if ( $similarity < $content_threshold ) {
+			if ( $similarity <= $content_threshold ) {
 				$duplicate_post = false;
 			}
 		}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -315,10 +315,11 @@ class API extends \WP_REST_Controller {
 		}
 
 		// Insert/update the post.
-		$local_post_id = wp_insert_post( $post_args );
+		$local_post_id = wp_insert_post( $post_args, true );
 
 		// Bail if the insert didn't work.
 		if ( is_wp_error( $local_post_id ) ) {
+			trigger_error( sprintf( 'Error inserting post: ', $local_post_id->get_error_message() ) );
 			return array( 'debug' => $local_post_id );
 		}
 

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -177,7 +177,7 @@ class Dashboard {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return JSON 
+	 * @return JSON
 	 */
 	public function get_objects_to_sync_count_via_ajax() {
 

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -606,7 +606,7 @@ class Press_Sync {
 			break;
 		}
 
-		$media['meta_input']['press_sync_post_id'] = $thumbnail_id;
+		$media['meta_input']['press_sync_id'] = $thumbnail_id;
 
 		return $media;
 	}

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -606,7 +606,7 @@ class Press_Sync {
 			break;
 		}
 
-		$media['meta_input']['press_sync_id'] = $thumbnail_id;
+		$media['meta_input']['press_sync_post_id'] = $thumbnail_id;
 
 		return $media;
 	}

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -247,7 +247,7 @@ class Press_Sync {
 		$where_clause = ( $where_clause ) ? ' AND ' . $where_clause : '';
 
 		// @TODO let's filter the where clause in general.
-		$where_clause .= $this->get_synced_post_clause( $objects_to_sync );
+		$where_clause .= $this->get_synced_object_clause( $objects_to_sync );
 
 		if ( $testing_post_id = absint( get_option( 'ps_testing_post' ) ) ) {
 			$id_where_clause = ' AND ID = %d ';
@@ -404,7 +404,7 @@ class Press_Sync {
 		global $wpdb;
 
 		$where_clause = '';
-		$where_clause = $this->get_synced_post_clause( $objects_to_sync );
+		$where_clause = $this->get_synced_object_clause( $objects_to_sync );
 
 		// If it's just one post return only 1.
 		if ( $testing_post_id = absint( get_option( 'ps_testing_post' ) ) ) {
@@ -1152,7 +1152,7 @@ class Press_Sync {
 	 *
 	 * @return string
 	 */
-	public function get_synced_post_clause( $objects_to_sync ) {
+	public function get_synced_object_clause( $objects_to_sync ) {
 		$synced_posts = $this->get_synced_object_ids( $objects_to_sync );
 
 		if ( ! get_option( 'ps_only_sync_missing' ) || empty( $synced_posts ) ) {

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -412,7 +412,11 @@ class Press_Sync {
 			return 1;
 		}
 
-		$prepared_sql  = $wpdb->prepare( "SELECT count(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status NOT IN ('auto-draft','trash') {$where_clause}", $objects_to_sync );
+		$query         = "SELECT count(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status NOT IN ('auto-draft','trash') {$where_clause}";
+		$prepared_sql  = $wpdb->prepare( $query, $objects_to_sync );
+
+		trigger_error( sprintf( 'Queried for count of posts to sync using: %s', $prepared_sql ) );
+
 		$total_objects = $wpdb->get_var( $prepared_sql );
 
 		return $total_objects;

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -1287,7 +1287,8 @@ class Press_Sync {
 	 * @return array
 	 */
 	public function get_synced_object_ids( $objects_to_sync ) {
-		$last_sync = get_option( "ps_synced_post_session_{$objects_to_sync}" );
+		$option_name = "ps_synced_post_session_{$objects_to_sync}";
+		$last_sync   = get_option( $option_name );
 
 		if ( is_array( $last_sync ) && ! empty( $last_sync ) ) {
 			return $last_sync;
@@ -1313,6 +1314,8 @@ class Press_Sync {
 		if ( empty( $response_body['data']['synced'] ) ) {
 			return array();
 		}
+
+		update_option( $option_name, $response_body['data']['synced'] );
 
 		return $response_body['data']['synced'];
 	}


### PR DESCRIPTION
This update allows for better handling of the fill-in for missing posts

- Stores IDs of synced posts in an option after the first page of results, allowing much quicker firing for subsequent pages
- Updates some checks and precautions
- Reintroduces fill-in functionality for non-post types
- Cleanup method for modifying WHERE clause for fill-in