### PR TITLE
Ticket/aotech 6661 sync taxonomies

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -208,7 +208,7 @@ class API extends \WP_REST_Controller {
 
 		$responses = array();
 
-		$objects_to_sync = in_array( $objects_to_sync, array( 'attachment', 'comment', 'user', 'option', 'post', 'page' ), true ) ? $objects_to_sync : 'post';
+		$objects_to_sync = in_array( $objects_to_sync, array( 'attachment', 'comment', 'user', 'option', 'post', 'page', 'taxonomy_term' ), true ) ? $objects_to_sync : 'post';
 
 		foreach ( $objects as $object ) {
 			$sync_method = "sync_{$objects_to_sync}";
@@ -1012,5 +1012,55 @@ SQL;
 				update_post_meta( $post_id, $field, maybe_unserialize( $values ) );
 			}
 		}
+	}
+
+	/**
+	 * Sync a taxonomy term to the remote site.
+	 *
+	 * @since NEXT
+	 * @param array $object_args The term taxonomy args.
+	 * @return string
+	 */
+	public function sync_taxonomy_term( $object_args ) {
+		try {
+			if ( ! taxonomy_exists( $object_args['taxonomy'] ) ) {
+				throw new \Exception( sprintf( 'The taxonomy %s does not exist, cannot insert terms.', $object_args['taxonomy'] ) );
+			}
+
+			$term_ids = term_exists( $object_args['name'], $object_args['taxonomy'] );
+
+			if ( ! is_array( $term_ids ) ) {
+				$term_ids = wp_insert_term( $object_args['name'], $object_args['taxonomy'], array(
+					'slug' => $object_args['slug'],
+				) );
+
+				if ( is_wp_error( $term_ids ) ) {
+					throw new \Exception( sprintf(
+						'There was an issue inserting term "%s" into taxonomy "%s": %s',
+						$object_args['name'],
+						$object_args['taxonomy'],
+						$term_ids->get_error_message()
+					) );
+				}
+			}
+
+			if ( ! empty( $object_args['meta_input'] ) ) {
+				foreach ( $object_args['meta_input'] as $meta_key => $meta_value ) {
+					$meta_value = is_array( $meta_value ) ? current( $meta_value ) : $meta_value;
+					update_term_meta( $term_ids['term_id'], $meta_key, $meta_value );
+				}
+			}
+		} catch ( \Exception $e ) {
+			trigger_error( $e->getMessage() );
+			return array(
+				'debug' => $e->getMessage(),
+			);
+		}
+
+		return array(
+			'debug' => array(
+				'message' => __( 'The taxonomy term was succesfully added.', 'press-sync' ),
+			),
+		);
 	}
 }


### PR DESCRIPTION
~NOTE: This PR incorporates PR #20~ #20 has been merged to master!

This changeset allows syncing of Taxonomies & Terms, which is a bit of a misnomer since taxonomies aren't created dynamically, but rather registered in core. I digress. This PR will sync terms between sites, including term meta. I attempted doing this data with posts but that has tow major drawbacks:

- Terms that aren't attached to posts will never sync
- Term meta operations are too cumbersome for the post sync process, resulting in much greater times between requests.