### PR TITLE
Ticket/aotech 6691 pages missing from sync

### DIFF
--- a/assets/js/press-sync.js
+++ b/assets/js/press-sync.js
@@ -117,7 +117,7 @@ window.PressSync = ( function( window, document, $ ) {
 
 			if ( response.data.total_objects_processed >= response.data.total_objects ) {
 				// Start the next batch at page 1.
-				if ( next_args.order_to_sync_all && next_args.order_to_sync_all.length ) {
+				if ( next_args && next_args.order_to_sync_all && next_args.order_to_sync_all.length ) {
 					return app.syncData( 1, null, next_args );
 				}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -217,7 +217,7 @@ class API extends \WP_REST_Controller {
 
 		$responses = array();
 
-		$objects_to_sync = in_array( $objects_to_sync, array( 'attachment', 'comment', 'user', 'option', 'post', 'page', 'taxonomy_term' ), true ) ? $objects_to_sync : 'post';
+		$objects_to_sync = in_array( $objects_to_sync, array( 'attachment', 'comment', 'user', 'option', 'taxonomy_term' ), true ) ? $objects_to_sync : 'post';
 
 		foreach ( $objects as $object ) {
 			$sync_method = "sync_{$objects_to_sync}";


### PR DESCRIPTION
Pages and posts don't need to be in the array of types checked, instead they should both fallback to 'post'.

Also addresses a minor bug in the recent JS updates.