### PR TITLE
Ticket/aotech 6700 duplicate terms

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -329,7 +329,7 @@ class API extends \WP_REST_Controller {
 			foreach ( $post_args['tax_input']['category'] as $category ) {
 				wp_insert_category( array(
 					'cat_name'             => $category['name'],
-					'category_description' => strlen( $category['description'] ) ? $category['description'] : '',
+					'category_description' => $category['description'],
 					'category_nicename'    => $category['slug'],
 				) );
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1062,7 +1062,8 @@ SQL;
 
 			if ( ! is_array( $term_ids ) ) {
 				$term_ids = wp_insert_term( $object_args['name'], $object_args['taxonomy'], array(
-					'slug' => $object_args['slug'],
+					'slug'        => $object_args['slug'],
+					'description' => $object_args['description'],
 				) );
 
 				if ( is_wp_error( $term_ids ) ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1161,16 +1161,16 @@ SQL;
 	 * @param string $taxonomy The taxonomy to attach the term to.
 	 */
 	private function create_term( $term, $taxonomy ) {
-		$term_res = wp_insert_term( $term['name'], $taxonomy, array(
+		$term_result = wp_insert_term( $term['name'], $taxonomy, array(
 			'slug'        => $term['slug'],
 			'description' => $term['description'],
 		) );
 
-		if ( is_wp_error( $term_res ) ) {
-			trigger_error( sprintf( __( 'Could not insert new term "%s": %s.', 'press-sync' ), $term['name'], $term_res->get_error_message() ) );
+		if ( is_wp_error( $term_result ) ) {
+			trigger_error( sprintf( __( 'Could not insert new term "%s": %s.', 'press-sync' ), $term['name'], $term_result->get_error_message() ) );
 		}
 
-		return $term_res['term_id'];
+		return $term_result['term_id'];
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -322,15 +322,18 @@ class API extends \WP_REST_Controller {
 		}
 
 		// Add categories.
-		if ( isset( $post_args['tax_input']['category'] ) && $post_args['tax_input']['category'] ) {
+		if ( ! empty( $post_args['tax_input']['category'] ) ) {
 
 			require_once( ABSPATH . '/wp-admin/includes/taxonomy.php' );
 
 			foreach ( $post_args['tax_input']['category'] as $category ) {
 				wp_insert_category( array(
-					'cat_name' => $category,
+					'cat_name'             => $category['name'],
+					'category_description' => strlen( $category['description'] ) ? $category['description'] : '',
+					'category_nicename'    => $category['slug'],
 				) );
-				$post_args['post_category'][] = $category;
+
+				$post_args['post_category'][] = $category['slug'];
 			}
 		}
 
@@ -1104,7 +1107,7 @@ SQL;
 		if ( isset( $post_args['tax_input'] ) ) {
 
 			foreach ( $post_args['tax_input'] as $taxonomy => $terms ) {
-				wp_set_object_terms( $post_id, $terms, $taxonomy, false );
+				wp_set_object_terms( $post_id, wp_list_pluck( $terms, 'slug' ), $taxonomy, false );
 			}
 		}
 	}

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -379,6 +379,12 @@ class Press_Sync {
 		foreach ( $taxonomies as $key => $taxonomy ) {
 			$taxonomies[ $taxonomy ] = get_the_terms( $object_id, $taxonomy ) ?: array();
 			unset( $taxonomies[ $key ] );
+
+			// Need to get term meta as well.
+			foreach ( $taxonomies[ $taxonomy ] as $term ) {
+				$term->meta_input = get_term_meta( $term->term_id ) ?: array();
+				$term->meta_input['press_sync_term_id'] = $term->term_id;
+			}
 		}
 
 		return $taxonomies;

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -377,7 +377,7 @@ class Press_Sync {
 	public function get_relationships( $object_id, $taxonomies ) {
 
 		foreach ( $taxonomies as $key => $taxonomy ) {
-			$taxonomies[ $taxonomy ] = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'names' ) );
+			$taxonomies[ $taxonomy ] = get_the_terms( $object_id, $taxonomy );
 			unset( $taxonomies[ $key ] );
 		}
 

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -377,7 +377,7 @@ class Press_Sync {
 	public function get_relationships( $object_id, $taxonomies ) {
 
 		foreach ( $taxonomies as $key => $taxonomy ) {
-			$taxonomies[ $taxonomy ] = get_the_terms( $object_id, $taxonomy );
+			$taxonomies[ $taxonomy ] = get_the_terms( $object_id, $taxonomy ) ?: array();
 			unset( $taxonomies[ $key ] );
 		}
 


### PR DESCRIPTION
Handles doing full term-data syncs when syncing posts (maintains slug and description). Also uses `get_the_terms` in place of `wp_get_object_terms`, which could prove useful for performance.