### PR TITLE
Ticket/aotech 6704 better author connections

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -645,6 +645,12 @@ class API extends \WP_REST_Controller {
 	 * @return integer $user_id
 	 */
 	public function get_press_sync_author_id( $user_id ) {
+		static $usermeta_prefix = 'press_sync_';
+
+		if ( is_multisite() ) {
+			$blog_id         = get_current_blog_id();
+			$usermeta_prefix = "press_sync_{$blog_id}_"; // Prefix looks like "press_sync_3_".
+		}
 
 		if ( ! $user_id ) {
 			return 1;
@@ -652,7 +658,7 @@ class API extends \WP_REST_Controller {
 
 		global $wpdb;
 
-		$sql = "SELECT user_id AS ID FROM $wpdb->usermeta WHERE meta_key = 'press_sync_user_id' AND meta_value = %d";
+		$sql = "SELECT user_id AS ID FROM {$wpdb->usermeta} WHERE meta_key = '{$usermeta_prefix}user_id' AND meta_value = %d";
 		$prepared_sql = $wpdb->prepare( $sql, $user_id );
 
 		$press_sync_user_id = $wpdb->get_var( $prepared_sql );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1140,7 +1140,6 @@ SQL;
 	}
 
 	/**
-<<<<<<< HEAD
 	 * Make a key multisite-specific by injecting the current blog ID.
 	 *
 	 * @since NEXT

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -653,7 +653,15 @@ class API extends \WP_REST_Controller {
 		}
 
 		if ( ! $user_id ) {
-			return 1;
+			/**
+			 * Filter for when we don't have a post author ID.
+			 *
+			 * @since NEXT
+			 *
+			 * @param  int $user_id The ID to use when we don't get an author.
+			 * @return int
+			 */
+			return apply_filters( 'press_sync_unknown_author', 1 );
 		}
 
 		global $wpdb;

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -297,6 +297,12 @@ class Press_Sync {
 	 * @return WP_Users
 	 */
 	public function get_users_to_sync( $next_page = 1 ) {
+		static $usermeta_prefix = 'press_sync_';
+
+		if ( is_multisite() ) {
+			$blog_id         = get_current_blog_id();
+			$usermeta_prefix = "press_sync_{$blog_id}_";
+		}
 
 		$query_args = array(
 			'number' => 5,
@@ -324,8 +330,8 @@ class Press_Sync {
 					$user['meta_input'][ $key ] = $value[0];
 				}
 
-				$user['meta_input']['press_sync_user_id'] = $user['ID'];
-				$user['meta_input']['press_sync_source']  = home_url();
+				$user['meta_input']["{$usermeta_prefix}user_id"] = $user['ID'];
+				$user['meta_input']["{$usermeta_prefix}source"]  = home_url();
 				$user['role'] = $role;
 
 				unset( $user['ID'] );

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -297,13 +297,6 @@ class Press_Sync {
 	 * @return WP_Users
 	 */
 	public function get_users_to_sync( $next_page = 1 ) {
-		static $usermeta_prefix = 'press_sync_';
-
-		if ( is_multisite() ) {
-			$blog_id         = get_current_blog_id();
-			$usermeta_prefix = "press_sync_{$blog_id}_";
-		}
-
 		$query_args = array(
 			'number' => 5,
 			'offset' => ( $next_page > 1 ) ? ( $next_page - 1 ) * 5 : 0,
@@ -330,8 +323,8 @@ class Press_Sync {
 					$user['meta_input'][ $key ] = $value[0];
 				}
 
-				$user['meta_input']["{$usermeta_prefix}user_id"] = $user['ID'];
-				$user['meta_input']["{$usermeta_prefix}source"]  = home_url();
+				$user['meta_input']['press_sync_user_id'] = $user['ID'];
+				$user['meta_input']['press_sync_source']  = home_url();
 				$user['role'] = $role;
 
 				unset( $user['ID'] );


### PR DESCRIPTION
This modifies the current post author logic to set and lookup authors based on multisite-specific meta keys in a multisite environment. Thus, authors on blog `2` will get the following meta

- (previous: `press_sync_user_id`) => `press_sync_2_user_id`
- (previous: `press_sync_source`) => `press_sync_2_source`

This allows proper attribution to authors when using multisite.