### PR TITLE
Ticket/aotech 6714 post validator

### DIFF
--- a/includes/api/route/Validation.php
+++ b/includes/api/route/Validation.php
@@ -1,6 +1,7 @@
 <?php
 namespace Press_Sync\api\route;
 
+use Press_Sync\api\route\validation\Post;
 use Press_Sync\api\route\validation\User;
 use Press_Sync\api\route\validation\Taxonomy;
 
@@ -27,6 +28,7 @@ class Validation extends \WP_REST_Controller {
 	protected $routes = array(
 		User::class,
 		Taxonomy::class,
+		Post::class,
 	);
 
 	/**

--- a/includes/api/route/validation/Post.php
+++ b/includes/api/route/validation/Post.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Press_Sync\api\route\validation;
+
+
+class Post {
+
+}

--- a/includes/api/route/validation/Post.php
+++ b/includes/api/route/validation/Post.php
@@ -1,8 +1,56 @@
 <?php
-
 namespace Press_Sync\api\route\validation;
 
+use Press_Sync\api\route\AbstractRoute;
 
-class Post {
+/**
+ * Class Post
+ *
+ * @package Press_Sync\api\route\validation
+ * @since NEXT
+ */
+class Post extends AbstractRoute {
+	/**
+	 * @var \Press_Sync\validation\Post
+	 *
+	 * @since NEXT
+	 */
+	protected $data_source;
 
+	/**
+	 * Post constructor.
+	 *
+	 * @since NEXT
+	 */
+	public function __construct() {
+		$this->rest_base   = 'validation/post';
+		$this->data_source = new \Press_Sync\validation\Post();
+	}
+
+	/**
+	 * Register hooks for Post validation.
+	 *
+	 * @since NEXT
+	 */
+	public function register_hooks() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes for Post validation.
+	 *
+	 * @since NEXT
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, "{$this->rest_base}/count", [
+			'methods'             => [ 'GET' ],
+			'callback'            => array( $this->data_source, 'get_count' ),
+			'permission_callback' => [ $this, 'validate_sync_key' ],
+			'args'                => [
+				'press_sync_key' => [
+					'required' => true,
+				],
+			],
+		] );
+	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1308,4 +1308,25 @@ SQL;
 
 		return $data;
 	}
+
+	/**
+	 * Get remote data from an API request.
+	 *
+	 * @since NEXT
+	 * @param  string $request The requested datapoint.
+	 * @return array
+	 */
+	public static function get_remote_data( $request ) {
+		$url = API::get_remote_url( get_option( 'ps_remote_domain' ), $request, array(
+			'press_sync_key' => get_option( 'ps_remote_key')
+		) );
+
+		$response = API::get_remote_response( $url );
+
+		if ( empty( $response['body'] ) ) {
+			return array();
+		}
+
+		return $response['body'];
+	}
 }

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -54,6 +54,10 @@ class CLI {
 	 * @since NEXT
 	 */
 	public function init_commands() {
+		if ( ! class_exists( '\WP_CLI' ) ) {
+			return;
+		}
+
 		foreach ( $this->commands as $command ) {
 			/* @var AbstractCliCommand $class */
 			$class = new $command();

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -3,6 +3,7 @@
 namespace Press_Sync;
 
 use Press_Sync\client\cli\AbstractCliCommand;
+use Press_Sync\client\cli\command\Validate;
 
 /**
  * CLI Support for Press Sync.
@@ -20,10 +21,15 @@ class CLI {
 	protected $plugin = null;
 
 	/**
-	 * @var
+	 * Commands registered to this plugin.
+	 *
+	 * @TODO Refactor everything currently into the constructor into standalone classes and add them to this array.
+	 *
+	 * @var array
+	 * @since NEXT
 	 */
 	protected $commands = array(
-		\Press_Sync\client\cli\ValidationCommand::class,
+		Validate::class,
 	);
 
 	/**

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -2,6 +2,8 @@
 
 namespace Press_Sync;
 
+use Press_Sync\client\cli\AbstractCliCommand;
+
 /**
  * CLI Support for Press Sync.
  *
@@ -16,6 +18,13 @@ class CLI {
 	 * @since 0.1.0
 	 */
 	protected $plugin = null;
+
+	/**
+	 * @var
+	 */
+	protected $commands = array(
+		\Press_Sync\client\cli\ValidationCommand::class,
+	);
 
 	/**
 	 * The constructor.
@@ -37,6 +46,19 @@ class CLI {
 		\WP_CLI::add_command( 'press-sync pages', array( $this, 'sync_pages' ) );
 		\WP_CLI::add_command( 'press-sync users', array( $this, 'sync_users' ) );
 		\WP_CLI::add_command( 'press-sync options', array( $this, 'sync_options' ) );
+	}
+
+	/**
+	 * Initialize concrete instances of AbstractCliCommand objects and register those commands w/ WP-CLI.
+	 *
+	 * @since NEXT
+	 */
+	public function init_commands() {
+		foreach ( $this->commands as $command ) {
+			/* @var AbstractCliCommand $class */
+			$class = new $command();
+			$class->register_command();
+		}
 	}
 
 	/**

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -78,10 +78,10 @@ class Press_Sync {
 	 * @since 0.1.0
 	 */
 	public function hooks() {
+		$this->cli->init_commands();
 		add_filter( 'http_request_host_is_external', array( $this, 'approve_localhost_urls' ), 10, 3 );
 		add_filter( 'press_sync_order_to_sync_all', array( $this, 'order_to_sync_all' ), 10, 1 );
 		add_filter( 'press_sync_after_prepare_post_args_to_sync', array( $this, 'maybe_remove_post_id' ) );
-
 		add_filter( 'press_sync_get_taxonomy_term_where', array( $this, 'maybe_get_terms_for_post' ) );
 	}
 

--- a/includes/client/cli/AbstractCliCommand.php
+++ b/includes/client/cli/AbstractCliCommand.php
@@ -1,0 +1,16 @@
+<?php
+namespace Press_Sync\client\cli;
+
+/**
+ * Class AbstractCliCommand
+ *
+ * @package Press_Sync\client\cli
+ * @since NEXT
+ */
+abstract class AbstractCliCommand extends \WP_CLI_Command {
+	/**
+	 * @since NEXT
+	 * @return void
+	 */
+	abstract public function register_command();
+}

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -54,8 +54,11 @@ class ValidationCommand extends AbstractCliCommand {
 	 * @since NEXT
 	 */
 	private function taxonomies( $args ) {
-		$taxonomy = new Taxonomy();
+		if ( is_multisite() && ! \WP_CLI::get_config( 'url' ) ) {
+			\WP_CLI::error( 'You must include the --url parameter when calling this command on WordPress multisite.' );
+		}
 
+		$taxonomy       = new Taxonomy();
 		$taxonomy_count = $taxonomy->get_unique_taxonomy_count();
 		$term_count     = $taxonomy->get_term_count_by_taxonomy();
 

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -55,16 +55,19 @@ class ValidationCommand extends AbstractCliCommand {
 		}
 
 		// Call the method in this class that handles the selected entity to validate.
-		$this->{$validation_entity}();
+		$this->{$validation_entity}( $assoc_args );
 	}
 
 	/**
 	 * Get validation data for the Taxonomy entity.
 	 *
+	 * @param array $args Associative arguments from the validate command.
+	 *
 	 * @throws ExitException Exception if url parameter is not passed in multisite.
+	 * @return void
 	 * @since NEXT
 	 */
-	private function taxonomies() {
+	private function taxonomies( $args ) {
 		if ( is_multisite() && ! \WP_CLI::get_config( 'url' ) ) {
 			\WP_CLI::error( 'You must include the --url parameter when calling this command on WordPress multisite.' );
 		}
@@ -101,9 +104,12 @@ class ValidationCommand extends AbstractCliCommand {
 	/**
 	 * Get validation data for Post entity.
 	 *
-	 * @throws ExitException
+	 * @param array $args Associative arguments from the validate command.
+	 *
+	 * @throws ExitException Throw exception if --url argument is missing on multisite.
+	 * @since NEXT
 	 */
-	private function posts() {
+	private function posts( $args ) {
 		if ( is_multisite() && ! \WP_CLI::get_config( 'url' ) ) {
 			\WP_CLI::error( 'You must include the --url parameter when calling this command on WordPress multisite.' );
 		}

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -46,7 +46,7 @@ class ValidationCommand extends AbstractCliCommand {
 		}
 
 		// Call the method in this class that handles the selected entity to validate.
-		$this->{$validation_entity}( $assoc_args );
+		$this->{$validation_entity}();
 	}
 
 	/**
@@ -55,14 +55,14 @@ class ValidationCommand extends AbstractCliCommand {
 	 * @throws ExitException Exception if url parameter is not passed in multisite.
 	 * @since NEXT
 	 */
-	private function taxonomies( $args ) {
+	private function taxonomies() {
 		if ( is_multisite() && ! \WP_CLI::get_config( 'url' ) ) {
 			\WP_CLI::error( 'You must include the --url parameter when calling this command on WordPress multisite.' );
 		}
 
-		$taxonomy       = new Taxonomy();
-		$taxonomy_count = $taxonomy->get_unique_taxonomy_count();
-		$term_count     = $taxonomy->get_term_count_by_taxonomy();
+		$count          = ( new Taxonomy() )->get_count();
+		$taxonomy_count = $count['unique_taxonomies'];
+		$term_count     = $count['term_count_by_taxonomy'];
 
 		\WP_CLI::line( 'Local domain results:' );
 		\WP_CLI::line( '' );

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -1,0 +1,59 @@
+<?php
+namespace Press_Sync\client\cli;
+
+use Press_Sync\validation\Taxonomy;
+
+/**
+ * Class ValidationCommand
+ *
+ * @package Press_Sync\client\cli
+ * @since NEXT
+ */
+class ValidationCommand extends AbstractCliCommand {
+	/**
+	 * Register our custom commands with WP-CLI.
+	 *
+	 * @since NEXT
+	 */
+	public function register_command() {
+		\WP_CLI::add_command( 'press-sync validate', array( $this, 'validate' ) );
+	}
+
+	/**
+	 * Validate data consistency between source site and destination site.
+	 *
+	 * @param array $args       Command arguments.
+	 * @param array $assoc_args Command associative arguments.
+	 * @return void
+	 *
+	 * @since NEXT
+	 */
+	public function validate( $args, $assoc_args ) {
+		if ( empty( $args ) ) {
+			\WP_CLI::warning( 'You must choose an entity type to validate.' );
+			return;
+		}
+
+		$validation_entity = filter_var( $args[0], FILTER_SANITIZE_STRING );
+
+		if ( ! method_exists( $this, $validation_entity ) ) {
+			\WP_CLI::warning( "{$validation_entity} is not a valid entity type." );
+			return;
+		}
+
+		// Call the method in this class that handles the selected entity to validate.
+		$this->{$validation_entity}();
+	}
+
+	/**
+	 * Get validation data for the Taxonomy entity.
+	 *
+	 * @since NEXT
+	 */
+	private function taxonomies() {
+		$taxonomy = new Taxonomy();
+
+		\WP_CLI\Utils\format_items( 'table', array( array( 'unique_taxonomies' => $taxonomy->get_unique_taxonomy_count() ) ), array( 'unique_taxonomies' ) );
+		\WP_CLI\Utils\format_items( 'table', $taxonomy->get_term_count_by_taxonomy(), array( 'taxonomy_name', 'number_of_terms' ) );
+	}
+}

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -25,6 +25,14 @@ class ValidationCommand extends AbstractCliCommand {
 	/**
 	 * Validate data consistency between source site and destination site.
 	 *
+	 * ## OPTIONS
+	 *
+	 * <validation_entity>
+	 * : The type of entity to validate.
+	 * options:
+	 *   - posts
+	 *   - taxonomies
+	 *
 	 * @param array $args       Command arguments.
 	 * @param array $assoc_args Command associative arguments.
 	 *

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -3,6 +3,7 @@ namespace Press_Sync\client\cli;
 
 use Press_Sync\validation\Taxonomy;
 use Press_Sync\API;
+use WP_CLI\ExitException;
 
 /**
  * Class ValidationCommand
@@ -51,6 +52,7 @@ class ValidationCommand extends AbstractCliCommand {
 	/**
 	 * Get validation data for the Taxonomy entity.
 	 *
+	 * @throws ExitException Exception if url parameter is not passed in multisite.
 	 * @since NEXT
 	 */
 	private function taxonomies( $args ) {

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -1,6 +1,7 @@
 <?php
 namespace Press_Sync\client\cli;
 
+use Press_Sync\validation\Post;
 use Press_Sync\validation\Taxonomy;
 use Press_Sync\API;
 use WP_CLI\ExitException;
@@ -86,6 +87,25 @@ class ValidationCommand extends AbstractCliCommand {
 
 		if ( $term_count !== $json['term_count_by_taxonomy'] ) {
 			\WP_CLI::warning( 'Discrepancy in taxonomy term counts.' );
+		}
+	}
+
+	/**
+	 * Get validation data for Post entity.
+	 *
+	 * @throws ExitException
+	 */
+	private function posts() {
+		if ( is_multisite() && ! \WP_CLI::get_config( 'url' ) ) {
+			\WP_CLI::error( 'You must include the --url parameter when calling this command on WordPress multisite.' );
+		}
+
+		$count = ( new Post() )->get_count();
+		$json = API::get_remote_data( 'validation/post/count' );
+
+		if ( $count !== $json ) {
+			\WP_CLI::warning( count( $count ) . ':' . count( $json ) );
+			\WP_CLI::warning( 'Discrepancy in post counts.' );
 		}
 	}
 }

--- a/includes/client/cli/Validation.php
+++ b/includes/client/cli/Validation.php
@@ -2,6 +2,7 @@
 namespace Press_Sync\client\cli;
 
 use Press_Sync\validation\Taxonomy;
+use Press_Sync\API;
 
 /**
  * Class ValidationCommand
@@ -24,9 +25,11 @@ class ValidationCommand extends AbstractCliCommand {
 	 *
 	 * @param array $args       Command arguments.
 	 * @param array $assoc_args Command associative arguments.
-	 * @return void
 	 *
+	 * @synopsis <validation_entity> [--remote_domain=<remote_domain>] [--remote_press_sync_key=<remote_press_sync_key>]
 	 * @since NEXT
+
+	 * @return void
 	 */
 	public function validate( $args, $assoc_args ) {
 		if ( empty( $args ) ) {
@@ -42,7 +45,7 @@ class ValidationCommand extends AbstractCliCommand {
 		}
 
 		// Call the method in this class that handles the selected entity to validate.
-		$this->{$validation_entity}();
+		$this->{$validation_entity}( $assoc_args );
 	}
 
 	/**
@@ -50,10 +53,35 @@ class ValidationCommand extends AbstractCliCommand {
 	 *
 	 * @since NEXT
 	 */
-	private function taxonomies() {
+	private function taxonomies( $args ) {
 		$taxonomy = new Taxonomy();
 
 		\WP_CLI\Utils\format_items( 'table', array( array( 'unique_taxonomies' => $taxonomy->get_unique_taxonomy_count() ) ), array( 'unique_taxonomies' ) );
 		\WP_CLI\Utils\format_items( 'table', $taxonomy->get_term_count_by_taxonomy(), array( 'taxonomy_name', 'number_of_terms' ) );
+
+		$json = $this->get_remote_data( 'taxonomy' );
+
+		\WP_CLI::success( print_r( $json, true ) );
+	}
+
+	/**
+	 * Get remote data from an API request.
+	 *
+	 * @since NEXT
+	 * @param  string $request The requested datapoint.
+	 * @return array
+	 */
+	public function get_remote_data( $request ) {
+		$url = API::get_remote_url( 'http://cmt-single.localhost/', "validation/taxonomy", array(
+			'request' => $request,
+		) );
+
+		$response = API::get_remote_response( $url );
+
+		if ( empty( $response['body']['success'] ) ) {
+			return array();
+		}
+
+		return $response['body']['data'];
 	}
 }

--- a/includes/client/cli/command/validate/Post.php
+++ b/includes/client/cli/command/validate/Post.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Press_Sync\client\cli\command\validate;
+
+use Press_Sync\API;
+use Press_Sync\validation\Post;
+use Press_Sync\validators\Validation_Interface;
+use WP_CLI\ExitException;
+
+
+/**
+ * Class PostValidator
+ *
+ * @package Press_Sync\client\cli\command\validate
+ */
+class PostValidator implements Validator, Validation_Interface {
+	/**
+	 * @var
+	 */
+	private $args;
+
+	/**
+	 * PostValidator constructor.
+	 *
+	 * @param $args
+	 */
+	public function __construct( $args ) {
+		$this->args = $args;
+	}
+
+	/**
+	 * Get validation data for Post entity.
+	 *
+	 * @param array $args Associative arguments from the validate command.
+	 *
+	 * @throws ExitException Throw exception if --url argument is missing on multisite.
+	 * @since NEXT
+	 */
+	public function validate() {
+		try {
+			if ( is_multisite() && ! \WP_CLI::get_config( 'url' ) ) {
+				throw new ExitException();
+			}
+
+			$post_count_data        = ( new Post() )->get_count();
+			$remote_post_count_data = API::get_remote_data( 'validation/post/count' );
+
+			$prepared_post_count_data        = $this->prepare_post_data_for_output( $post_count_data );
+			$prepared_remote_post_count_data = $this->prepare_post_data_for_output( $remote_post_count_data );
+
+			\WP_CLI::line( 'Local post counts by type and status:' );
+			$this->output_post_data_table( $prepared_post_count_data );
+
+			\WP_CLI::line( 'Remote post counts by type and status:' );
+			$this->output_post_data_table( $prepared_remote_post_count_data );
+
+			if ( $prepared_post_count_data !== $prepared_remote_post_count_data ) {
+				\WP_CLI::warning( 'Discrepancy in post counts.' );
+			}
+		} catch ( ExitException $e ) {
+			\WP_CLI::error( 'You must include the --url parameter when calling this command on WordPress multisite.' );
+		}
+	}
+
+	public function compare_results() {
+		// TODO: Implement compare_results() method.
+	}
+
+	public function get_source_data() {
+		// TODO: Implement get_source_data() method.
+	}
+
+	public function get_destination_data() {
+		// TODO: Implement get_destination_data() method.
+	}
+
+	public static function register_api_endpoints() {
+		// TODO: Implement register_api_endpoints() method.
+	}
+
+	/**
+	 * Outputs the post data table in the CLI.
+	 *
+	 * @param array $post_data Table data.
+	 */
+	private function output_post_data_table( $post_data ) {
+		\WP_CLI\Utils\format_items( 'table', $post_data, array_keys( $post_data[0] ) );
+	}
+
+	/**
+	 * @param $post_data
+	 *
+	 * @return array
+	 */
+	private function prepare_post_data_for_output( $post_data ) {
+		$table_values = array();
+
+		foreach ( $post_data as $post_type => $post_status_count ) {
+			$new_array              = array();
+			$new_array['post_type'] = $post_type;
+
+			foreach ( $post_status_count as $status => $count ) {
+				$new_array[ $status ] = $count;
+			}
+
+			$table_values[] = $new_array;
+		}
+
+		return $table_values;
+	}
+}

--- a/includes/client/cli/command/validate/Validator.php
+++ b/includes/client/cli/command/validate/Validator.php
@@ -1,0 +1,16 @@
+<?php
+namespace Press_Sync\client\cli\command\validate;
+
+/**
+ * Interface Validator
+ *
+ * @package Press_Sync\client\cli\command\validate
+ * @since NEXT
+ */
+interface Validator {
+	/**
+	 * @return void
+	 * @since NEXT
+	 */
+	public function validate();
+}

--- a/includes/validation/CountInterface.php
+++ b/includes/validation/CountInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace Press_Sync\validation;
+
+interface CountInterface {
+	public function get_count();
+}

--- a/includes/validation/Post.php
+++ b/includes/validation/Post.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Press_Sync\validation;
+
+
+class Post {
+
+}

--- a/includes/validation/Post.php
+++ b/includes/validation/Post.php
@@ -1,7 +1,15 @@
 <?php
 namespace Press_Sync\validation;
 
+/**
+ * Class Post
+ *
+ * @package Press_Sync\validation
+ */
 class Post implements CountInterface {
+	/**
+	 *
+	 */
 	public function get_count() {
 		// TODO: Implement get_count() method.
 	}

--- a/includes/validation/Post.php
+++ b/includes/validation/Post.php
@@ -1,8 +1,8 @@
 <?php
-
 namespace Press_Sync\validation;
 
-
-class Post {
-
+class Post implements CountInterface {
+	public function get_count() {
+		// TODO: Implement get_count() method.
+	}
 }

--- a/includes/validation/Post.php
+++ b/includes/validation/Post.php
@@ -8,9 +8,18 @@ namespace Press_Sync\validation;
  */
 class Post implements CountInterface {
 	/**
+	 * Get the number of posts for all registered post types.
 	 *
+	 * @return array
+	 * @since NEXT
 	 */
 	public function get_count() {
-		// TODO: Implement get_count() method.
+		$posts = array();
+
+		foreach ( get_post_types() as $type ) {
+			$posts[ $type ] = wp_count_posts( $type );
+		}
+
+		return $posts;
 	}
 }

--- a/includes/validation/Taxonomy.php
+++ b/includes/validation/Taxonomy.php
@@ -7,7 +7,7 @@ namespace Press_Sync\validation;
  * @package Press_Sync\validation
  * @since   NEXT
  */
-class Taxonomy {
+class Taxonomy implements CountInterface {
 	/**
 	 * Get the number of unique taxonomies in this WordPress installation.
 	 *

--- a/includes/validation/Taxonomy.php
+++ b/includes/validation/Taxonomy.php
@@ -26,7 +26,10 @@ class Taxonomy {
 		$terms = [];
 
 		foreach ( get_taxonomies() as $name => $taxonomy ) {
-			$terms[ $name ] = count( get_terms( array( 'taxonomy' => $taxonomy ) ) );
+			$terms[] = array(
+				'taxonomy_name'   => $name,
+				'number_of_terms' => count( get_terms( array( 'taxonomy' => $taxonomy ) ) ),
+			);
 		}
 
 		return $terms;

--- a/includes/validation/Taxonomy.php
+++ b/includes/validation/Taxonomy.php
@@ -28,7 +28,12 @@ class Taxonomy {
 		foreach ( get_taxonomies() as $name => $taxonomy ) {
 			$terms[] = array(
 				'taxonomy_name'   => $name,
-				'number_of_terms' => count( get_terms( array( 'taxonomy' => $taxonomy ) ) ),
+				'number_of_terms' => count(
+					get_terms( array(
+						'taxonomy'   => $taxonomy,
+						'hide_empty' => false,
+					)
+				) ),
 			);
 		}
 


### PR DESCRIPTION
Zach, here's some work in progress for the post validator. I might continue to give this a look tonight since we had a lot of meetings today. If you run `wp press-sync validate posts` and pass in a URL parameter in multisite, you should see output for all of the registered post types along with their counts for various statuses in a nice table. You'll also see output of post types for the remote site, but without data, because I haven't normalized the return data just yet. That's something I'm working on sorting out.