### PR TITLE
Feature/meta sync

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -32,6 +32,38 @@ class API extends \WP_REST_Controller {
 	private $fix_terms = false;
 
 	/**
+	 * Whether we're skipping asset sync.
+	 *
+	 * @var bool
+	 * @since NEXT
+	 */
+	private $skip_assets = false;
+
+	/**
+	 * Whether we're preserving post-type object IDs.
+	 *
+	 * @var bool
+	 * @since NEXT
+	 */
+	private $preserve_ids = false;
+
+	/**
+	 * The content threshold for comparing duplicate post_content.
+	 *
+	 * @var int
+	 * @since NEXT
+	 */
+	private $content_threshold;
+
+	/**
+	 * Array of meta fields to sync if we're only syncing meta for post-type objects.
+	 *
+	 * @var array
+	 * @since NEXT
+	 */
+	private $ps_sync_meta_fields = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 0.1.0

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1267,7 +1267,7 @@ SQL;
 		$meta_result = array();
 
 		foreach ( $post_args['meta_input'] as $field => $value ) {
-			if ( false === strpos( $field, 'press_sync_' ) && ! in_array( $field, $this->ps_meta_repair_fields ) ) {
+			if ( ! $this->plugin->is_repair_meta_field( $field, $this->ps_meta_repair_fields ) ) {
 				continue;
 			}
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -405,9 +405,20 @@ class API extends \WP_REST_Controller {
 		if ( ! $this->skip_assets && ! array_key_exists( 'attachment_url', $attachment_args ) ) {
 			return false;
 		}
-		// Check to see if the post exists.
-		$local_attachment = $this->get_synced_post( $attachment_args );
-		echo '<pre>', print_r($local_attachment, true); die;
+
+		if ( ! empty( $this->ps_meta_repair_fields ) ) {
+			$attachment_args['post_type'] = 'attachment';
+			$local_attachment             = $this->get_synced_post( $attachment_args );
+
+			if ( ! $local_attachment ) {
+				return array(
+					'debug' => array(
+						'message' => __( 'Could not find a local post to repair meta for.', 'press-sync' ),
+					),
+				);
+			}
+			return $this->maybe_repair_meta_fields( $local_attachment, $attachment_args );
+		}
 
 		if ( isset( $attachment_args['ID'] ) ) {
 			$import_id = $attachment_args['ID'];

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -405,6 +405,9 @@ class API extends \WP_REST_Controller {
 		if ( ! $this->skip_assets && ! array_key_exists( 'attachment_url', $attachment_args ) ) {
 			return false;
 		}
+		// Check to see if the post exists.
+		$local_attachment = $this->get_synced_post( $attachment_args );
+		echo '<pre>', print_r($local_attachment, true); die;
 
 		if ( isset( $attachment_args['ID'] ) ) {
 			$import_id = $attachment_args['ID'];
@@ -1258,7 +1261,7 @@ SQL;
 	 * @param  array $post_args  Array of incoming post arguments.
 	 * @return array
 	 */
-	private function maybe_repair_meta_fields( $local_post, $post_args )
+	private function maybe_repair_meta_fields( $local_post, $post_args ) {
 		$meta_result = array();
 
 		foreach ( $post_args['meta_input'] as $field => $value ) {

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -44,6 +44,7 @@ class Dashboard {
 		'ps_fix_terms',
 		'ps_delta_date',
 		'ps_content_threshold',
+		'ps_meta_repair_fields',
 	];
 
 	/**

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -44,7 +44,7 @@ class Dashboard {
 		'ps_fix_terms',
 		'ps_delta_date',
 		'ps_content_threshold',
-		'ps_meta_repair_fields',
+		'ps_sync_meta_fields',
 	];
 
 	/**

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -1595,14 +1595,10 @@ SQL;
 	 * @return array
 	 */
 	public function maybe_repair_meta( $posts ) {
-		$meta_fields = get_option( 'ps_meta_repair_fields' );
-
-		if ( ! $meta_fields ) {
+		if ( empty( get_option( 'ps_meta_repair_fields' ) ) ) {
 			return $posts;
 		}
 
-		$meta_fields = explode( ',', $meta_fields );
-		$meta_fields = array_map( 'trim', $meta_fields );
 		$meta_posts  = array();
 
 		foreach ( $posts as $post ) {
@@ -1612,7 +1608,7 @@ SQL;
 			);
 
 			foreach ( $post['meta_input'] as $field => $value ) {
-				if ( false === strpos( $field, 'press_sync_' ) && ! in_array( $field, $meta_fields ) ) {
+				if ( ! $this->is_repair_meta_field( $field ) ) {
 					continue;
 				}
 
@@ -1647,5 +1643,31 @@ SQL;
 		$join_clause   = $GLOBALS['wpdb']->prepare( $join_clause, $meta_fields );
 
 		return $join_clause;
+	}
+
+	/**
+	 * Check to see if the meta field is in the set specified for repair.
+	 *
+	 * @since NEXT
+	 * @param  string $field  The meta field to test.
+	 * @param  array  $fields The meta fields in the repair set.
+	 * @return bool
+	 */
+	public function is_repair_meta_field( $field, $fields = array() ) {
+		if ( empty( $fields ) ) {
+			$fields = get_option( 'ps_meta_repair_fields' );
+			$fields = explode( ',', $fields );
+			$fields = array_map( 'trim', $fields );
+		}
+
+		if ( 0 === strpos( $field, 'press_sync_' ) ) {
+			return true;
+		}
+
+		if( in_array( $field, $fields ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -1625,6 +1625,13 @@ SQL;
 		return $meta_posts;
 	}
 
+	/**
+	 * If we're repairing post meta, we only need to join get posts that match the fields to sync.
+	 *
+	 * @since NEXT
+	 * @param  string $join_clause The current JOIN clause.
+	 * @return string
+	 */
 	public function maybe_join_post_meta( $join_clause ) {
 		$meta_fields = get_option( 'ps_meta_repair_fields' );
 

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -81,8 +81,8 @@ class Press_Sync {
 		add_filter( 'http_request_host_is_external', array( $this, 'approve_localhost_urls' ), 10, 3 );
 		add_filter( 'press_sync_order_to_sync_all', array( $this, 'order_to_sync_all' ), 10, 1 );
 		add_filter( 'press_sync_after_prepare_post_args_to_sync', array( $this, 'maybe_remove_post_id' ) );
-
 		add_filter( 'press_sync_get_taxonomy_term_where', array( $this, 'maybe_get_terms_for_post' ) );
+		add_filter( 'press_sync_posts_to_sync', [ $this, 'maybe_repair_meta' ] );
 	}
 
 	/**
@@ -256,7 +256,6 @@ class Press_Sync {
 	 * @return array  $posts           The posts to return.
 	 */
 	public function get_posts_to_sync( $objects_to_sync, $next_page = 1, $taxonomies = [], $where_clause = '' ) {
-
 		global $wpdb;
 
 		$offset       = ( $next_page > 1 ) ? ( $next_page - 1 ) * 5 : 0;
@@ -293,8 +292,15 @@ class Press_Sync {
 			}
 		}
 
+		/**
+		 * Filters the posts that we got to sync.
+		 *
+		 * @since NEXT
+		 * @param  array $posts The posts that we got to sync.
+		 * @return array
+		 */
+		$posts = apply_filters( 'press_sync_posts_to_sync', $posts );
 		return $posts;
-
 	}
 
 	/**
@@ -1041,18 +1047,19 @@ class Press_Sync {
 	public function parse_sync_settings( $settings = array() ) {
 
 		return wp_parse_args( $settings, array(
-			'remote_domain'        => get_option( 'ps_remote_domain' ),
-			'ps_remote_key'        => get_option( 'ps_remote_key' ),
-			'sync_method'          => get_option( 'ps_sync_method' ),
-			'objects_to_sync'      => get_option( 'ps_objects_to_sync' ),
-			'duplicate_action'     => get_option( 'ps_duplicate_action' ),
-			'force_update'         => get_option( 'ps_force_update', false ),
-			'skip_assets'          => get_option( 'ps_skip_assets', false ),
-			'options'              => get_option( 'ps_options_to_sync' ),
-			'local_folder'         => '',
-			'preserve_ids'         => get_option( 'ps_preserve_ids', false ),
-			'fix_terms'            => get_option( 'ps_fix_terms', false ),
-			'ps_content_threshold' => get_option( 'ps_content_threshold', false ),
+			'remote_domain'         => get_option( 'ps_remote_domain' ),
+			'ps_remote_key'         => get_option( 'ps_remote_key' ),
+			'sync_method'           => get_option( 'ps_sync_method' ),
+			'objects_to_sync'       => get_option( 'ps_objects_to_sync' ),
+			'duplicate_action'      => get_option( 'ps_duplicate_action' ),
+			'force_update'          => get_option( 'ps_force_update', false ),
+			'skip_assets'           => get_option( 'ps_skip_assets', false ),
+			'options'               => get_option( 'ps_options_to_sync' ),
+			'local_folder'          => '',
+			'preserve_ids'          => get_option( 'ps_preserve_ids', false ),
+			'fix_terms'             => get_option( 'ps_fix_terms', false ),
+			'ps_content_threshold'  => get_option( 'ps_content_threshold', false ),
+			'ps_meta_repair_fields' => get_option( 'ps_meta_repair_fields' ),
 		) );
 	}
 
@@ -1566,5 +1573,43 @@ SQL;
 		}
 
 		return $GLOBALS['wpdb']->prepare( ' AND post_modified >= %s ', $this->delta_date );
+	}
+
+	/**
+	 * If we have the meta repair option, we are only sending post ID and applicable meta.
+	 *
+	 * @since NEXT
+	 * @param  array $posts The posts that we got to send over.
+	 * @return array
+	 */
+	public function maybe_repair_meta( $posts ) {
+		$meta_fields = get_option( 'ps_meta_repair_fields' );
+
+		if ( ! $meta_fields ) {
+			return $posts;
+		}
+
+		$meta_fields = explode( ',', $meta_fields );
+		$meta_fields = array_map( 'trim', $meta_fields );
+		$meta_posts  = array();
+
+		foreach ( $posts as $post ) {
+			$meta_post = array(
+				'ID'         => $post['ID'],
+				'meta_input' => array(),
+			);
+
+			foreach ( $post['meta_input'] as $field => $value ) {
+				if ( false === strpos( $field, 'press_sync_' ) && ! in_array( $field, $meta_fields ) ) {
+					continue;
+				}
+
+				$meta_post['meta_input'][ $field ] = $value;
+			}
+
+			$meta_posts[] = $meta_post;
+		}
+
+		return $meta_posts;
 	}
 }

--- a/views/dashboard/html-advanced.php
+++ b/views/dashboard/html-advanced.php
@@ -46,6 +46,13 @@ if ( ! apply_filters( 'press_sync_show_advanced_options', false ) ) {
 				</td>
 			</tr>
 			<tr valign="top">
+				<th scope="row">Post Meta Repair</th>
+				<td>
+					<input type="input" name="ps_meta_repair_fields" value="<?php echo esc_attr( get_option( 'ps_meta_repair_fields' ) ); ?>" />
+					<span>Comma-separated list of post meta fields to sync. Other fields (including Post fields) will be ignored.</span>
+				</td>
+			</tr>
+			<tr valign="top">
 				<td colspan="2">
                     <p><strong>Settings below this line may affect performance if altered.</strong></p>
 				</td>

--- a/views/dashboard/html-advanced.php
+++ b/views/dashboard/html-advanced.php
@@ -46,9 +46,9 @@ if ( ! apply_filters( 'press_sync_show_advanced_options', false ) ) {
 				</td>
 			</tr>
 			<tr valign="top">
-				<th scope="row">Post Meta Repair</th>
+				<th scope="row">Post Meta Sync</th>
 				<td>
-					<input type="input" name="ps_meta_repair_fields" value="<?php echo esc_attr( get_option( 'ps_meta_repair_fields' ) ); ?>" />
+					<input type="input" name="ps_sync_meta_fields" value="<?php echo esc_attr( get_option( 'ps_sync_meta_fields' ) ); ?>" />
 					<span>Comma-separated list of post meta fields to sync. Other fields (including Post fields) will be ignored.</span>
 				</td>
 			</tr>


### PR DESCRIPTION
This PR incorporates #35 

The intent of this PR is to allow the ability to sync meta fields for posts and attachments instead of the entire post object.

This could be useful in situations where metadata is backfilled or updated on the source site, but we don't need to resync all posts completely.