### PR TITLE
Ticket/aotech 6774 incorrect post ids

### DIFF
--- a/assets/js/press-sync.js
+++ b/assets/js/press-sync.js
@@ -2,6 +2,8 @@ window.PressSync = ( function( window, document, $ ) {
 
 	var app = {};
 
+	app.PAGE_SIZE = 1;
+
 	app.init = function() {
 		$(document).on( 'click', '.press-sync-button', app.pressSyncButton );
 	};
@@ -66,7 +68,8 @@ window.PressSync = ( function( window, document, $ ) {
 
 		if ( request_time ) {
 			// Estimate time remaining.
-			var remaining_time = ( ( ( total_objects - total_objects_processed ) / 5 ) * request_time ) / 60 / 60;
+			var remaining_time = ( ( ( total_objects - total_objects_processed ) / app.PAGE_SIZE ) * request_time );
+			remaining_time = remaining_time / 60 / 60;
 			var time_left_suffix = 'hours';
 
 			// Shift to minutes.

--- a/assets/js/press-sync.js
+++ b/assets/js/press-sync.js
@@ -26,6 +26,10 @@ window.PressSync = ( function( window, document, $ ) {
 		}).done(function( response ) {
 			app.updateProgressBar( response.data.objects_to_sync, 0, response.data.total_objects );
 
+			if ( response.data.page_size ) {
+				app.PAGE_SIZE = response.data.page_size;
+			}
+
 			if ( 'all' == response.data.objects_to_sync ) {
 				app.syncAll();
 			} else {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1117,6 +1117,11 @@ SQL;
 		// Set taxonomies for custom post type.
 		if ( isset( $post_args['tax_input'] ) ) {
 			foreach ( $post_args['tax_input'] as $taxonomy => $terms ) {
+				if ( 2 == count( $terms ) ) {
+					wp_set_object_terms( $post_id, $terms['slug'], $terms['taxonomy'], true );
+					wp_remove_object_terms( $post_id, 'uncategorized', 'category' );
+					continue;
+				}
 				$this->maybe_create_new_terms( $taxonomy, $terms );
 				wp_set_object_terms( $post_id, wp_list_pluck( $terms, 'slug' ), $taxonomy, false );
 			}

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1117,7 +1117,7 @@ SQL;
 		// Set taxonomies for custom post type.
 		if ( isset( $post_args['tax_input'] ) ) {
 			foreach ( $post_args['tax_input'] as $taxonomy => $terms ) {
-				if ( 2 == count( $terms ) ) {
+				if ( $this->is_short_term_sync( $terms ) ) {
 					wp_set_object_terms( $post_id, $terms['slug'], $terms['taxonomy'], true );
 					wp_remove_object_terms( $post_id, 'uncategorized', 'category' );
 					continue;
@@ -1236,5 +1236,16 @@ SQL;
 				trigger_error( sprintf( __( 'Could not add term meta for term %d.', 'press-sync' ), $term_id ) );
 			}
 		}
+	}
+
+	/**
+	 * Determine if we're syncing short terms.
+	 *
+	 * @since NEXT
+	 * @param  array $terms The array of terms to test.
+	 * @return bool
+	 */
+	private function is_short_term_sync( $terms ) {
+		return 2 == count( $terms );
 	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1117,7 +1117,7 @@ SQL;
 		// Set taxonomies for custom post type.
 		if ( isset( $post_args['tax_input'] ) ) {
 			foreach ( $post_args['tax_input'] as $taxonomy => $terms ) {
-				if ( $this->is_short_term_sync( $terms ) ) {
+				if ( $this->is_partial_term_sync( $terms ) ) {
 					wp_set_object_terms( $post_id, $terms['slug'], $terms['taxonomy'], true );
 					wp_remove_object_terms( $post_id, 'uncategorized', 'category' );
 					continue;
@@ -1239,13 +1239,13 @@ SQL;
 	}
 
 	/**
-	 * Determine if we're syncing short terms.
+	 * Determine if we're syncing partial terms with the post object.
 	 *
 	 * @since NEXT
 	 * @param  array $terms The array of terms to test.
 	 * @return bool
 	 */
-	private function is_short_term_sync( $terms ) {
+	private function is_partial_term_sync( $terms ) {
 		return 2 == count( $terms );
 	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -253,7 +253,7 @@ class API extends \WP_REST_Controller {
 		$local_post = $this->get_synced_post( $post_args );
 
 		// Check to see a non-synced duplicate of the post exists.
-		if ( 'sync' === $duplicate_action && ! $local_post ) {
+		if ( 'sync' === $duplicate_action && ! $local_post && ! $this->preserve_ids ) {
 			$local_post = $this->get_non_synced_duplicate( $post_args );
 		}
 

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -44,7 +44,7 @@ class Dashboard {
 		'ps_fix_terms',
 		'ps_delta_date',
 		'ps_content_threshold',
-		'ps_short_terms',
+		'ps_partial_terms',
 		'ps_page_size',
 	];
 

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -45,6 +45,7 @@ class Dashboard {
 		'ps_delta_date',
 		'ps_content_threshold',
 		'ps_short_terms',
+		'ps_page_size',
 	];
 
 	/**
@@ -190,8 +191,9 @@ class Dashboard {
 		$objects_to_sync = get_option( 'ps_objects_to_sync' );
 
 		wp_send_json_success( array(
-			'objects_to_sync'  => $objects_to_sync,
-			'total_objects'    => $this->plugin->count_objects_to_sync( $objects_to_sync ),
+			'objects_to_sync' => $objects_to_sync,
+			'total_objects'   => $this->plugin->count_objects_to_sync( $objects_to_sync ),
+			'page_size'       => $this->plugin::PAGE_SIZE,
 		) );
 	}
 

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -44,6 +44,7 @@ class Dashboard {
 		'ps_fix_terms',
 		'ps_delta_date',
 		'ps_content_threshold',
+		'ps_short_terms',
 	];
 
 	/**

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -13,7 +13,13 @@ namespace Press_Sync;
  * @since 0.1.0
  */
 class Press_Sync {
-	const PAGE_SIZE = 1;
+	/**
+	 * Default page size for sync batches.
+	 *
+	 * @since NEXT
+	 * @var int
+	 */
+	const PAGE_SIZE = 5;
 
 	/**
 	 * Plugin class

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -392,7 +392,7 @@ class Press_Sync {
 	 * @return array $taxonomies
 	 */
 	public function get_relationships( $object_id, $taxonomies ) {
-		if ( $this->settings['ps_short_terms'] ) {
+		if ( $this->settings['ps_partial_terms'] ) {
 			/**
 			 * Get just the terms and taxonomies.
 			 */
@@ -1086,7 +1086,7 @@ SQL;
 			'preserve_ids'         => get_option( 'ps_preserve_ids', false ),
 			'fix_terms'            => get_option( 'ps_fix_terms', false ),
 			'ps_content_threshold' => get_option( 'ps_content_threshold', false ),
-			'ps_short_terms'       => get_option( 'ps_short_terms', false ),
+			'ps_partial_terms'     => get_option( 'ps_partial_terms', false ),
 			'ps_page_size'         => get_option( 'ps_page_size', self::PAGE_SIZE ),
 		) );
 

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -260,7 +260,7 @@ class Press_Sync {
 
 		global $wpdb;
 
-		$offset       = ( $next_page > 1 ) ? ( $next_page - 1 ) * self::PAGE_SIZE : 0;
+		$offset       = ( $next_page > 1 ) ? ( $next_page - 1 ) * $this->settings['ps_page_size'] : 0;
 		$where_clause = ( $where_clause ) ? ' AND ' . $where_clause : '';
 
 		// @TODO let's filter the where clause in general.
@@ -272,7 +272,7 @@ class Press_Sync {
 			$where_clause   .= $wpdb->prepare( $id_where_clause, $testing_post_id );
 		}
 
-		$page_size    = self::PAGE_SIZE;
+		$page_size    = $this->settings['ps_page_size'];
 		$sql          = "SELECT * FROM {$wpdb->posts} WHERE post_type = %s AND post_status NOT IN ('auto-draft','trash') {$where_clause} ORDER BY post_date DESC LIMIT {$page_size} OFFSET %d";
 		$prepared_sql = $wpdb->prepare( $sql, $objects_to_sync, $offset );
 
@@ -310,8 +310,8 @@ class Press_Sync {
 	 */
 	public function get_users_to_sync( $next_page = 1 ) {
 		$query_args = array(
-			'number' => self::PAGE_SIZE,
-			'offset' => ( $next_page > 1 ) ? ( $next_page - 1 ) * self::PAGE_SIZE : 0,
+			'number' => $this->settings['ps_page_size'],
+			'offset' => ( $next_page > 1 ) ? ( $next_page - 1 ) * $this->settings['ps_page_size'] : 0,
 			'paged'  => $next_page,
 		);
 
@@ -1026,7 +1026,7 @@ SQL;
 		return array(
 			'objects_to_sync'         => $content_type,
 			'total_objects'           => $total_objects,
-			'total_objects_processed' => ( $next_page * self::PAGE_SIZE ) - ( self::PAGE_SIZE - count( $objects ) ),
+			'total_objects_processed' => ( $next_page * $this->settings['ps_page_size'] ) - ( $this->settings['ps_page_size'] - count( $objects ) ),
 			'next_page'               => $next_page + 1,
 			'log'                     => $logs,
 		);
@@ -1081,6 +1081,7 @@ SQL;
 			'fix_terms'            => get_option( 'ps_fix_terms', false ),
 			'ps_content_threshold' => get_option( 'ps_content_threshold', false ),
 			'ps_short_terms'       => get_option( 'ps_short_terms', false ),
+			'ps_page_size'         => get_option( 'ps_page_size', self::PAGE_SIZE ),
 		) );
 
 		return $this->settings;
@@ -1361,7 +1362,7 @@ SQL;
 
 		if ( 0 < $page_offset && 1 === absint( $next_page ) ) {
 
-			$page_offset = floor( $page_offset / self::PAGE_SIZE );
+			$page_offset = floor( $page_offset / $this->settings['ps_page_size'] );
 			$next_page  += ( $page_offset - 1);
 
 			error_log( '----NP: ' . $next_page );
@@ -1480,7 +1481,7 @@ SQL;
 	 * @return array
 	 */
 	public function get_taxonomy_term_to_sync( $next_page ) {
-		$offset = ( $next_page * self::PAGE_SIZE ) - self::PAGE_SIZE;
+		$offset = ( $next_page * $this->settings['ps_page_size'] ) - $this->settings['ps_page_size'];
 		$select = '';
 		$joins  = '';
 		$where  = ' WHERE 1=1 ';
@@ -1532,7 +1533,7 @@ SQL;
 {$joins}
 {$where}
 ORDER BY t.term_id ASC
-LIMIT {$offset}, self::PAGE_SIZE
+LIMIT {$offset}, $this->settings['ps_page_size']
 SQL;
 
 		return $GLOBALS['wpdb']->get_results( $sql, ARRAY_A );

--- a/views/dashboard/html-advanced.php
+++ b/views/dashboard/html-advanced.php
@@ -46,6 +46,16 @@ if ( ! apply_filters( 'press_sync_show_advanced_options', false ) ) {
 				</td>
 			</tr>
 			<tr valign="top">
+				<th scope="row">Short Terms</th>
+				<td>
+					<input type="checkbox" name="ps_short_terms" <?php checked( get_option( 'ps_short_terms' ) ); ?> value="1" />
+					<span>
+					If you've already synced terms and taxonomies to the remote site, this option can speed up the transfer of posts and mitigate
+					syncing problems associated with one-to-many post-term relationships and larger-than-average post bodies.
+					</span>
+				</td>
+			</tr>
+			<tr valign="top">
 				<td colspan="2">
                     <p><strong>Settings below this line may affect performance if altered.</strong></p>
 				</td>

--- a/views/dashboard/html-advanced.php
+++ b/views/dashboard/html-advanced.php
@@ -55,6 +55,13 @@ if ( ! apply_filters( 'press_sync_show_advanced_options', false ) ) {
 					</span>
 				</td>
 			</tr>
+            <tr>
+                <th scope="row">Page Size</th>
+                <td>
+                    <input type="number" name="ps_page_size" min="1" max="100" value="<?php echo esc_attr( get_option( 'ps_page_size' ) ); ?>" />
+                    <p>The size of each batch sent, default and recommendd is 5.</p>
+                </td>
+            </tr>
 			<tr valign="top">
 				<td colspan="2">
                     <p><strong>Settings below this line may affect performance if altered.</strong></p>

--- a/views/dashboard/html-advanced.php
+++ b/views/dashboard/html-advanced.php
@@ -46,9 +46,9 @@ if ( ! apply_filters( 'press_sync_show_advanced_options', false ) ) {
 				</td>
 			</tr>
 			<tr valign="top">
-				<th scope="row">Short Terms</th>
+				<th scope="row">Partial Terms</th>
 				<td>
-					<input type="checkbox" name="ps_short_terms" <?php checked( get_option( 'ps_short_terms' ) ); ?> value="1" />
+					<input type="checkbox" name="ps_partial_terms" <?php checked( get_option( 'ps_partial_terms' ) ); ?> value="1" />
 					<span>
 					If you've already synced terms and taxonomies to the remote site, this option can speed up the transfer of posts and mitigate
 					syncing problems associated with one-to-many post-term relationships and larger-than-average post bodies.


### PR DESCRIPTION
This issue was related to post data being truncated in transit with very large data loads. One example is a post that had 78 term relationships. Press Sync, by default, will attempt to sync full term data - slug, name, order, termmeta. In a batch of even 2-3 posts, this can cause the data the be truncated. The truncation of the post data resulted in inconsistencies such as the `import_id` not being in the payload, or `post_meta` altogether not being present.

This ticket addresses the issues presented in two ways:

- Batch size is reduced from 5 to 1 post at a time. This will be configurable in the future.
- There is now a "Short Terms" option added to the Advanced tab that will only send term slugs and taxonomies with posts. This is intended to be used in conjunction with the "Taxonomies & Terms" sync being run first. 