### PR TITLE
Get first array value instead of serializing.

### DIFF
--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -611,7 +611,7 @@ class Press_Sync {
 			}
 
 			if ( is_array( $meta_value ) ) {
-				$media['meta_input'][$meta_key] = serialize( $meta_value );
+				$media['meta_input'][$meta_key] = current( $meta_value );
 			}
 		}
 


### PR DESCRIPTION
Simple fix for getting attachment metadata over to the remote site correctly. Previously, meta was being updated as serialzied array strings, e.g.

```
s:2203:{a:40:{s:5:"width":i:3:100...
```

as opposed to

```
a:40:{s:5:"width":i:3:100...
```