### PR TITLE
Ticket/aotech 6787 sync meta

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1278,8 +1278,10 @@ SQL;
 
 		$new_count    = 0;
 		$update_count = 0;
+
 		foreach ( $object as $meta_key => $meta_value ) {
 			$meta_value    = is_array( $meta_value ) ? current( $meta_value ) : $meta_value;
+			$meta_value    = maybe_unserialize( $meta_value );
 			$update_result = update_post_meta( $post_id, $meta_key, $meta_value );
 
 			if ( is_numeric( $update_result ) ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1268,6 +1268,7 @@ SQL;
 		$new_count    = 0;
 		$update_count = 0;
 		foreach ( $object as $meta_key => $meta_value ) {
+			$meta_value    = is_array( $meta_value ) ? current( $meta_value ) : $meta_value;
 			$update_result = update_post_meta( $post_id, $meta_key, $meta_value );
 
 			if ( is_numeric( $update_result ) ) {

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -235,6 +235,10 @@ class Press_Sync {
 			$objects = $this->get_taxonomy_term_to_sync( $next_page );
 			break;
 
+		case 'meta':
+			$objects = $this->get_meta_to_sync( $next_page );
+			break;
+
 		default:
 			$objects = $this->get_posts_to_sync( $objects_to_sync, $next_page, $taxonomies, $where_clause );
 			break;
@@ -450,6 +454,10 @@ SQL;
 
 		if ( 'taxonomy_term' === $objects_to_sync ) {
 			return $this->count_taxonomy_term_to_sync();
+		}
+
+		if ( 'meta' === $objects_to_sync ) {
+			return $this->count_meta_to_sync();
 		}
 
 		// If it's just one post return only 1.
@@ -1139,6 +1147,7 @@ SQL;
 			'attachment'    => __( 'Media', 'press-sync' ),
 			'page'          => __( 'Pages', 'press-sync' ),
 			'post'          => __( 'Posts', 'press-sync' ),
+			'meta'          => __( 'Post Meta', 'press-sync' ),
 			'user'          => __( 'Users', 'press-sync' ),
 			'option'        => __( 'Options', 'press-sync' ),
 		);
@@ -1326,7 +1335,7 @@ SQL;
 	 * @return string $wp_object
 	 */
 	public function get_sync_function_name( $objects_to_sync = '' ) {
-		$wp_object = in_array( $objects_to_sync, array( 'attachment', 'comment', 'user', 'option', 'taxonomy_term' ), true ) ? $objects_to_sync : 'post';
+		$wp_object = in_array( $objects_to_sync, array( 'attachment', 'comment', 'user', 'option', 'taxonomy_term', 'meta' ), true ) ? $objects_to_sync : 'post';
 		return "prepare_{$wp_object}_args_to_sync";
 	}
 
@@ -1597,5 +1606,73 @@ SQL;
 		}
 
 		return $GLOBALS['wpdb']->prepare( ' AND post_modified >= %s ', $this->delta_date );
+	}
+
+	/**
+	 * Gets a count of meta rows to sync.
+	 *
+	 * @since NEXT
+	 * @return int
+	 */
+	public function count_meta_to_sync() {
+		$query = <<<SQL
+SELECT DISTINCT
+	post_id
+FROM
+	{$GLOBALS['wpdb']->postmeta} pm
+JOIN
+	{$GLOBALS['wpdb']->posts} p ON ( p.ID = pm.post_id )
+WHERE
+	p.post_status NOT IN ( 'auto-draft', 'trash' )
+SQL;
+
+		$results = $GLOBALS['wpdb']->get_results( $query );
+		return count( $results );
+	}
+
+	/**
+	 * Gets the meta data to sync.
+	 *
+	 * @since NEXT
+	 * @param  int   $next_page The page to get meta for.
+	 * @return array
+	 */
+	public function get_meta_to_sync( $next_page ) {
+		$offset = ( $next_page * $this->settings['ps_page_size'] ) - $this->settings['ps_page_size'];
+
+		$query = <<<SQL
+SELECT DISTINCT
+	post_id
+FROM
+	{$GLOBALS['wpdb']->postmeta} pm
+JOIN
+	{$GLOBALS['wpdb']->posts} p ON ( p.ID = pm.post_id )
+WHERE
+	p.post_status NOT IN ( 'auto-draft', 'trash' )
+LIMIT
+	{$offset}, {$this->settings['ps_page_size']}
+SQL;
+
+		$results = $GLOBALS['wpdb']->get_results( $query, ARRAY_A );
+
+		$meta = array();
+		foreach ( $results as $row ) {
+			$meta_row               = get_post_meta( $row['post_id'] );
+			$meta_row['_import_id'] = $row['post_id'];
+			$meta[]                 = $meta_row;
+		}
+
+		return $meta;
+	}
+
+	/**
+	 * Prepare meta to sync. Nothing to do here for now, just stubbed for compatibility.
+	 *
+	 * @since NEXT
+	 * @param  array $meta The incoming meta array.
+	 * @return array
+	 */
+	public function prepare_meta_args_to_sync( $meta ) {
+		return $meta;
 	}
 }


### PR DESCRIPTION
This pull request adds the ability to sync post meta directly from the UI. Typically this won't be necessary, but with some issues in a previous migration, this was a faster alternative to syncing the entire post dataset.

Marking as On Hold as this has changes from #39 