### PR TITLE
Ticket/aotech 6795 arbitrary cli options

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -175,14 +175,13 @@ class API extends \WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function sync_objects( $request ) {
-
 		$objects_to_sync         = $request->get_param( 'ps_objects_to_sync' );
 		$objects                 = $request->get_param( 'objects' );
 		$duplicate_action        = $request->get_param( 'ps_duplicate_action' ) ? $request->get_param( 'ps_duplicate_action' ) : 'skip';
 		$force_update            = $request->get_param( 'ps_force_update' );
-		$this->skip_assets       = 'true' == $request->get_param( 'ps_skip_assets' );
-		$this->preserve_ids      = 'true' == $request->get_param( 'ps_preserve_ids' );
-		$this->fix_terms         = 'true' == $request->get_param( 'ps_fix_terms' );
+		$this->skip_assets       = (bool) $request->get_param( 'ps_skip_assets' );
+		$this->preserve_ids      = (bool) $request->get_param( 'ps_preserve_ids' );
+		$this->fix_terms         = (bool) $request->get_param( 'ps_fix_terms' );
 		$this->content_threshold = absint( $request->get_param( 'ps_content_threshold' ) );
 
 		if ( ! $objects_to_sync ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -176,13 +176,13 @@ class API extends \WP_REST_Controller {
 	 */
 	public function sync_objects( $request ) {
 
-		$objects_to_sync         = $request->get_param( 'objects_to_sync' );
+		$objects_to_sync         = $request->get_param( 'ps_objects_to_sync' );
 		$objects                 = $request->get_param( 'objects' );
-		$duplicate_action        = $request->get_param( 'duplicate_action' ) ? $request->get_param( 'duplicate_action' ) : 'skip';
-		$force_update            = $request->get_param( 'force_update' );
-		$this->skip_assets       = (bool) $request->get_param( 'skip_assets' );
-		$this->preserve_ids      = (bool) $request->get_param( 'preserve_ids' );
-		$this->fix_terms         = (bool) $request->get_param( 'fix_terms' );
+		$duplicate_action        = $request->get_param( 'ps_duplicate_action' ) ? $request->get_param( 'ps_duplicate_action' ) : 'skip';
+		$force_update            = $request->get_param( 'ps_force_update' );
+		$this->skip_assets       = 'true' == $request->get_param( 'ps_skip_assets' );
+		$this->preserve_ids      = 'true' == $request->get_param( 'ps_preserve_ids' );
+		$this->fix_terms         = 'true' == $request->get_param( 'ps_fix_terms' );
 		$this->content_threshold = absint( $request->get_param( 'ps_content_threshold' ) );
 
 		if ( ! $objects_to_sync ) {

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -80,7 +80,7 @@ class API extends \WP_REST_Controller {
 			'methods'             => array( 'GET' ),
 			'callback'            => array( $this, 'get_sync_progress' ),
 			'permission_callback' => array( $this, 'validate_sync_key' ),
-			'args'                => array( 'post_type', 'press_sync_key', 'preserve_ids' ),
+			'args'                => array( 'post_type', 'press_sync_key', 'ps_preserve_ids' ),
 		) );
 
 		/*
@@ -918,7 +918,7 @@ class API extends \WP_REST_Controller {
                 $post_type = 'post';
             }
 
-            if ( (bool) $request->get_param( 'preserve_ids' ) ) {
+            if ( $this->preserve_ids ) {
                 $sql = <<<SQL
 SELECT DISTINCT
     ID

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -42,20 +42,43 @@ class CLI {
 	/**
 	 * Synchronize ALL content.
 	 *
+	 * ## OPTIONS
+	 *
+	 * [--<field>=<value>]
+	 * : May be any valid Press Sync option - unspecified options will be parsed from the database options.
+	 * - ps_remote_domain     - The domain of the remote site.
+	 * - ps_remote_key        - The remote site Press Sync key.
+	 * - ps_sync_method       - The sync method (push or pull).
+	 * - ps_duplicate_action  - Action to take for duplicate posts.
+	 * - ps_force_update      - Whether or not to force update of posts.
+	 * - ps_skip_assets       - Whether to skip full attachment uploads.
+	 * - ps_options_to_sync   - Comma-separated list of wp_options to sync.
+	 * - ps_preserve_ids      - Whether to preserve the IDs of post-type objects.
+	 * - ps_content_threshold - Set to a number > 0 to compare duplicates based on content.
+	 * - ps_partial_terms     - Set true if terms are already synced, allows for smaller post payloads.
+	 * - ps_page_size         - The number of objects to sync in a batch.
+	 *
+	 * [--local_folder=<local_folder>]
+	 * : The local folder of JSON data to read instead of the source database.
+	 *
+	 * [--verbose]
+	 * : Display logs from the remote server during processing.
+	 *
 	 * @since 0.6.1
 	 *
 	 * @param array $args       The arguments.
 	 * @param array $assoc_args The associative arugments.
 	 *
-	 * @synopsis [--remote_domain=<remote_domain>] [--remote_press_sync_key=<remote_press_sync_key>] [--local_folder=<local_folder>]
+	 * @synopsis [--<field>=<value>] [--local_folder=<local_folder>] [--verbose]
 	 */
 	public function sync_all( $args, $assoc_args ) {
+		$assoc_args = $this->parse_assoc_args( $assoc_args );
 
 		// Get all of the objects to sync in the order that we need them.
 		$order_to_sync_all = apply_filters( 'press_sync_order_to_sync_all', array() );
 
 		foreach ( $order_to_sync_all as $wp_object ) {
-			$assoc_args['objects_to_sync'] = $wp_object;
+			$assoc_args['ps_objects_to_sync'] = $wp_object;
 			$response = $this->plugin->sync_object( $wp_object, $assoc_args, 1, false, true );
 			$this->return_response( $response );
 		}
@@ -66,14 +89,37 @@ class CLI {
 	/**
 	 * Synchronize posts.
 	 *
+	 * ## OPTIONS
+	 *
+	 * [--<field>=<value>]
+	 * : May be any valid Press Sync option - unspecified options will be parsed from the database options.
+	 * - ps_remote_domain     - The domain of the remote site.
+	 * - ps_remote_key        - The remote site Press Sync key.
+	 * - ps_sync_method       - The sync method (push or pull).
+	 * - ps_duplicate_action  - Action to take for duplicate posts.
+	 * - ps_force_update      - Whether or not to force update of posts.
+	 * - ps_skip_assets       - Whether to skip full attachment uploads.
+	 * - ps_options_to_sync   - Comma-separated list of wp_options to sync.
+	 * - ps_preserve_ids      - Whether to preserve the IDs of post-type objects.
+	 * - ps_fix_terms         - Whether terms should be repaired instead of doing a normal sync.
+	 * - ps_content_threshold - Set to a number > 0 to compare duplicates based on content.
+	 * - ps_partial_terms     - Set true if terms are already synced, allows for smaller post payloads.
+	 * - ps_page_size         - The number of objects to sync in a batch.
+	 *
+	 * [--local_folder=<local_folder>]
+	 * : The local folder of JSON data to read instead of the source database.
+	 *
+	 * [--verbose]
+	 * : Display logs from the remote server during processing.
+	 *
+	 * @synopsis [--local_folder=<local_folder>] [--<field>=<value>]
+	 *
 	 * @param array $args       The arguments.
 	 * @param array $assoc_args The associative arugments.
-	 *
-	 * @synopsis [--remote_domain=<remote_domain>] [--remote_press_sync_key=<remote_press_sync_key>] [--local_folder=<local_folder>]
 	 */
 	public function sync_posts( $args, $assoc_args ) {
-
-		$response = $this->plugin->sync_object( 'post', $assoc_args, 1, false, true );
+		$assoc_args = $this->parse_assoc_args( $assoc_args );
+		$response   = $this->plugin->sync_object( 'post', $assoc_args, 1, false, true );
 
 		$this->return_response( $response );
 	}
@@ -157,5 +203,33 @@ class CLI {
 		} else {
 			\WP_CLI::error( 'There was a porblem. All of the content didn\'t sync.' );
 		}
+	}
+
+	/**
+	 * Parse the associative arguments with the Press Sync settings.
+	 *
+	 * @since NEXT
+	 * @param  array $assoc_args The associative args from the command line.
+	 * @return array
+	 */
+	private function parse_assoc_args( $assoc_args ) {
+		$valid_keys   = array_keys( $this->plugin->parse_sync_settings() );
+		$valid_keys[] = 'verbose';
+
+		foreach ( $assoc_args as $key => $value ) {
+			if ( in_array( $key, $valid_keys ) ){
+				continue;
+			}
+
+			unset( $assoc_args[ $key ] );
+		}
+
+		$final_args = $this->plugin->parse_sync_settings( $assoc_args );
+
+		foreach ( $final_args as $key => $value ) {
+			\WP_CLI::line( sprintf( "Arg set: [%s] => %s", $key, $value ) );
+		}
+
+		return $assoc_args;
 	}
 }

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -46,19 +46,19 @@ class CLI {
 	 *
 	 * [--<field>=<value>]
 	 * : May be any valid Press Sync option - unspecified options will be parsed from the database options.
-	 * - ps_remote_domain     - The domain of the remote site.
-	 * - ps_remote_key        - The remote site Press Sync key.
-	 * - ps_sync_method       - The sync method (push or pull).
-	 * - ps_duplicate_action  - Action to take for duplicate posts.
-	 * - ps_force_update      - Whether or not to force update of posts.
-	 * - ps_skip_assets       - Whether to skip full attachment uploads.
-	 * - ps_options_to_sync   - Comma-separated list of wp_options to sync.
-	 * - ps_preserve_ids      - Whether to preserve the IDs of post-type objects.
-	 * - ps_content_threshold - Set to a number > 0 to compare duplicates based on content.
-	 * - ps_partial_terms     - Set true if terms are already synced, allows for smaller post payloads.
-	 * - ps_page_size         - The number of objects to sync in a batch.
+	 * - ps-remote-domain     - The domain of the remote site.
+	 * - ps-remote-key        - The remote site Press Sync key.
+	 * - ps-sync-method       - The sync method (push or pull).
+	 * - ps-duplicate-action  - Action to take for duplicate posts.
+	 * - ps-force-update      - Whether or not to force update of posts.
+	 * - ps-skip-assets       - Whether to skip full attachment uploads.
+	 * - ps-options-to-sync   - Comma-separated list of wp_options to sync.
+	 * - ps-preserve-ids      - Whether to preserve the IDs of post-type objects.
+	 * - ps-content-threshold - Set to a number > 0 to compare duplicates based on content.
+	 * - ps-partial-terms     - Set true if terms are already synced, allows for smaller post payloads.
+	 * - ps-page-size         - The number of objects to sync in a batch.
 	 *
-	 * [--local_folder=<local_folder>]
+	 * [--local-folder=<local_folder>]
 	 * : The local folder of JSON data to read instead of the source database.
 	 *
 	 * [--verbose]
@@ -69,7 +69,7 @@ class CLI {
 	 * @param array $args       The arguments.
 	 * @param array $assoc_args The associative arugments.
 	 *
-	 * @synopsis [--<field>=<value>] [--local_folder=<local_folder>] [--verbose]
+	 * @synopsis [--<field>=<value>] [--local-folder=<local_folder>] [--verbose]
 	 */
 	public function sync_all( $args, $assoc_args ) {
 		$assoc_args = $this->parse_assoc_args( $assoc_args );
@@ -93,26 +93,26 @@ class CLI {
 	 *
 	 * [--<field>=<value>]
 	 * : May be any valid Press Sync option - unspecified options will be parsed from the database options.
-	 * - ps_remote_domain     - The domain of the remote site.
-	 * - ps_remote_key        - The remote site Press Sync key.
-	 * - ps_sync_method       - The sync method (push or pull).
-	 * - ps_duplicate_action  - Action to take for duplicate posts.
-	 * - ps_force_update      - Whether or not to force update of posts.
-	 * - ps_skip_assets       - Whether to skip full attachment uploads.
-	 * - ps_options_to_sync   - Comma-separated list of wp_options to sync.
-	 * - ps_preserve_ids      - Whether to preserve the IDs of post-type objects.
-	 * - ps_fix_terms         - Whether terms should be repaired instead of doing a normal sync.
-	 * - ps_content_threshold - Set to a number > 0 to compare duplicates based on content.
-	 * - ps_partial_terms     - Set true if terms are already synced, allows for smaller post payloads.
-	 * - ps_page_size         - The number of objects to sync in a batch.
+	 * - ps-remote-domain     - The domain of the remote site.
+	 * - ps-remote-key        - The remote site Press Sync key.
+	 * - ps-sync-method       - The sync method (push or pull).
+	 * - ps-duplicate-action  - Action to take for duplicate posts.
+	 * - ps-force-update      - Whether or not to force update of posts.
+	 * - ps-skip-assets       - Whether to skip full attachment uploads.
+	 * - ps-options-to-sync   - Comma-separated list of wp_options to sync.
+	 * - ps-preserve-ids      - Whether to preserve the IDs of post-type objects.
+	 * - ps-fix-terms         - Whether terms should be repaired instead of doing a normal sync.
+	 * - ps-content-threshold - Set to a number > 0 to compare duplicates based on content.
+	 * - ps-partial-terms     - Set true if terms are already synced, allows for smaller post payloads.
+	 * - ps-page-size         - The number of objects to sync in a batch.
 	 *
-	 * [--local_folder=<local_folder>]
+	 * [--local-folder=<local_folder>]
 	 * : The local folder of JSON data to read instead of the source database.
 	 *
 	 * [--verbose]
 	 * : Display logs from the remote server during processing.
 	 *
-	 * @synopsis [--local_folder=<local_folder>] [--<field>=<value>]
+	 * @synopsis [--local-folder=<local_folder>] [--<field>=<value>]
 	 *
 	 * @param array $args       The arguments.
 	 * @param array $assoc_args The associative arugments.
@@ -213,18 +213,23 @@ class CLI {
 	 * @return array
 	 */
 	private function parse_assoc_args( $assoc_args ) {
-		$valid_keys   = array_keys( $this->plugin->parse_sync_settings() );
-		$valid_keys[] = 'verbose';
+		$valid_keys    = array_keys( $this->plugin->parse_sync_settings() );
+		$valid_keys[]  = 'verbose';
+		$prepared_args = [];
 
-		foreach ( $assoc_args as $key => $value ) {
+		foreach ( $assoc_args as $key => $arg ) {
+			$prepared_args[ strtr( $key, [ '-' => '_' ] ) ] = $arg;
+		}
+
+		foreach ( $prepared_args as $key => $value ) {
 			if ( in_array( $key, $valid_keys ) ){
 				continue;
 			}
 
-			unset( $assoc_args[ $key ] );
+			unset( $prepared_args[ $key ] );
 		}
 
-		$final_args = $this->plugin->parse_sync_settings( $assoc_args );
+		$final_args = $this->plugin->parse_sync_settings( $prepared_args );
 
 		foreach ( $final_args as $key => $value ) {
 			\WP_CLI::line( sprintf( "Arg set: [%s] => %s", $key, $value ) );

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -64,12 +64,15 @@ class CLI {
 	 * [--verbose]
 	 * : Display logs from the remote server during processing.
 	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt after displaying sync settings.
+	 *
 	 * @since 0.6.1
 	 *
 	 * @param array $args       The arguments.
 	 * @param array $assoc_args The associative arugments.
 	 *
-	 * @synopsis [--<field>=<value>] [--local-folder=<local_folder>] [--verbose]
+	 * @synopsis [--<field>=<value>] [--local-folder=<local_folder>] [--verbose] [--yes]
 	 */
 	public function sync_all( $args, $assoc_args ) {
 		$assoc_args = $this->parse_assoc_args( $assoc_args );
@@ -112,10 +115,13 @@ class CLI {
 	 * [--verbose]
 	 * : Display logs from the remote server during processing.
 	 *
-	 * @synopsis [--local-folder=<local_folder>] [--<field>=<value>]
+	 * [--yes]
+	 * : Skip the confirmation prompt after displaying sync settings.
 	 *
 	 * @param array $args       The arguments.
 	 * @param array $assoc_args The associative arugments.
+	 *
+	 * @synopsis [--local-folder=<local_folder>] [--<field>=<value>] [--yes]
 	 */
 	public function sync_posts( $args, $assoc_args ) {
 		$assoc_args = $this->parse_assoc_args( $assoc_args );
@@ -234,6 +240,8 @@ class CLI {
 		foreach ( $final_args as $key => $value ) {
 			\WP_CLI::line( sprintf( "Arg set: [%s] => %s", $key, $value ) );
 		}
+
+		\WP_CLI::confirm( 'Sync with these settings?', $assoc_args );
 
 		return $final_args;
 	}

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -214,6 +214,15 @@ class CLI {
 	/**
 	 * Parse the associative arguments with the Press Sync settings.
 	 *
+	 * Things that are covered here:
+	 * - Converts dashes "-" to underscore "_" for option names.
+	 * - Checks against a list of "valid arguments" from the main plugin class to avoid unexpected arguments coming in.
+	 * - Parses the associative args array with the settings in the main plugin, so that CLI args and options from the
+	 * database are merged.
+	 *
+	 * This will also output the arguments that are being used in the current sync process and a confirmation dialog.
+	 * You can also pass the --yes argument to skip the confirmation.
+	 *
 	 * @since NEXT
 	 * @param  array $assoc_args The associative args from the command line.
 	 * @return array

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -235,6 +235,6 @@ class CLI {
 			\WP_CLI::line( sprintf( "Arg set: [%s] => %s", $key, $value ) );
 		}
 
-		return $assoc_args;
+		return $final_args;
 	}
 }

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -1087,7 +1087,13 @@ SQL;
 		$from_options = array();
 
 		foreach ( $default_settings as $option => $default ) {
-			$from_options[ $option ] = get_option( $option, $default );
+			$value = get_option( $option, $default );
+
+			if ( 'false' === $value ) {
+				$value = false;
+			}
+
+			$from_options[ $option ] = $value;
 		}
 
 		$this->settings = wp_parse_args( $settings, $from_options );

--- a/includes/class-press-sync.php
+++ b/includes/class-press-sync.php
@@ -1064,25 +1064,44 @@ SQL;
 	 * @return array $settings
 	 */
 	public function parse_sync_settings( $settings = array() ) {
-
-		$this->settings = wp_parse_args( $settings, array(
-			'remote_domain'        => get_option( 'ps_remote_domain' ),
-			'ps_remote_key'        => get_option( 'ps_remote_key' ),
-			'sync_method'          => get_option( 'ps_sync_method' ),
-			'objects_to_sync'      => get_option( 'ps_objects_to_sync' ),
-			'duplicate_action'     => get_option( 'ps_duplicate_action' ),
-			'force_update'         => get_option( 'ps_force_update', false ),
-			'skip_assets'          => get_option( 'ps_skip_assets', false ),
-			'options'              => get_option( 'ps_options_to_sync' ),
+		static $default_settings = array(
+			'ps_remote_domain'     => null,
+			'ps_sync_method'       => null,
+			'ps_objects_to_sync'   => null,
+			'ps_duplicate_action'  => null,
+			'ps_force_update'      => false,
+			'ps_skip_assets'       => false,
+			'ps_options_to_sync'   => null,
+			'ps_preserve_ids'      => false,
+			'ps_fix_terms'         => false,
+			'ps_remote_key'        => null,
+			'ps_content_threshold' => false,
+			'ps_partial_terms'     => false,
+			'ps_page_size'         => self::PAGE_SIZE,
+			'ps_delta_date'        => null,
+			'ps_testing_post'      => null,
 			'local_folder'         => '',
-			'preserve_ids'         => get_option( 'ps_preserve_ids', false ),
-			'fix_terms'            => get_option( 'ps_fix_terms', false ),
-			'ps_content_threshold' => get_option( 'ps_content_threshold', false ),
-			'ps_partial_terms'     => get_option( 'ps_partial_terms', false ),
-			'ps_page_size'         => get_option( 'ps_page_size', self::PAGE_SIZE ),
-		) );
+			'verbose'              => false,
+		);
 
-		return $this->settings;
+		$from_options = array();
+
+		foreach ( $default_settings as $option => $default ) {
+			$from_options[ $option ] = get_option( $option, $default );
+		}
+
+		$this->settings = wp_parse_args( $settings, $from_options );
+
+		/**
+		 * Filter the settings for Press Sync.
+		 *
+		 * Allows filtering the settings before they are passed along for processing data.
+		 *
+		 * @since NEXT
+		 * @param  array $settings The settings array after parsing options.
+		 * @return array
+		 */
+		return apply_filters( 'press_sync_settings', $this->settings );
 	}
 
 	/**

--- a/includes/class-progress.php
+++ b/includes/class-progress.php
@@ -47,13 +47,17 @@ class Progress {
 	/**
 	 * Update the progress that some objects have been processed.
 	 */
-	public function tick() {
+	public function tick( $message = '' ) {
 
 		if ( ! $this->cli_enabled ) {
 			return;
 		}
 
 		$this->progress->tick();
+
+		if ( $this->plugin->settings['verbose'] ) {
+			\WP_CLI::line( $message );
+		}
 	}
 
 	/**


### PR DESCRIPTION
This Pull Request allows options to be passed to CLI that are currently only configurable in the UI.

For example, now you can run

```
wp press-sync posts --ps_preserve_ids=true --ps_delta_date="2018-02-01" --ps_partial_terms=true
```

There is also a preliminary `--verbose` option that will attempt to log the result of API requests to the console. 